### PR TITLE
Port Rayekk fork fixes + Win11 theme

### DIFF
--- a/Shared/Enums/Function.cs
+++ b/Shared/Enums/Function.cs
@@ -545,5 +545,11 @@
         // Resolved per emulated type in the VIIPER forwarder (touchpad only exists on Sony/Deck).
         Viiper_DesktopButtonTarget,     // string - Legion "Desktop" front button -> emulated button
         Viiper_PageButtonTarget,        // string - Legion "Page" front button -> emulated button
+
+        // Enable/disable the built-in touch screen digitizer via SetupAPI device disable
+        // (HIDClass device matched by compatible ID UP:000D_U:0004 - never the localized
+        // friendly name). Not Legion-specific hardware, but only surfaced on Legion Go for now.
+        // (Ported from Rayekkk fork d790f307; appended at the END per the positional-wire-id rule.)
+        TouchscreenEnabled,             // bool - true = touch input active, false = digitizer disabled
     }
 }

--- a/Shared/Enums/Function.cs
+++ b/Shared/Enums/Function.cs
@@ -539,5 +539,11 @@
         // Helper -> widget push: a registered tile combo fired. Content = the tile id/tag.
         // Widget re-dispatches it through the normal tile-click handler (SimulateTileHotkeyFired).
         TileHotkeyFired,                // string - tile id/tag that the combo activated (helper -> widget)
+
+        // VIIPER: which emulated-controller button the Legion front buttons act as while
+        // controller emulation is active. String value: none|guide|touchpad|share|options|l3|r3.
+        // Resolved per emulated type in the VIIPER forwarder (touchpad only exists on Sony/Deck).
+        Viiper_DesktopButtonTarget,     // string - Legion "Desktop" front button -> emulated button
+        Viiper_PageButtonTarget,        // string - Legion "Page" front button -> emulated button
     }
 }

--- a/XboxGamingBar/App.xaml.cs
+++ b/XboxGamingBar/App.xaml.cs
@@ -557,10 +557,18 @@ namespace XboxGamingBar
 
         private async void DesktopView_CloseRequested(object sender, SystemNavigationCloseRequestedPreviewEventArgs e)
         {
-            // No widget alive → this is a plain desktop app close; let it through.
-            if (gamingXboxGameBarWidget == null)
+            // Only intervene when Game Bar is ACTIVELY showing the widget on screen right now.
+            // A widget instance can exist (gamingXboxGameBarWidget != null) long after Game Bar's
+            // overlay was last opened - Game Bar backgrounds it instead of destroying it - and in
+            // that case closing the desktop window carries no visible risk: nothing is on screen
+            // for Windows to disrupt, and even if the process suspends, Game Bar just cold-starts
+            // the widget fresh next time it's opened, same as any normal launch. Only redirect to
+            // minimize when the overlay is actually up (widget.Visible), the one moment closing
+            // the last OS-visible window really could suspend the process out from under a
+            // visible Game Bar session and show "Something went wrong with this widget".
+            if (gamingXboxGameBarWidget == null || gamingXboxGameBarWidget.Visible != true)
             {
-                Logger.Info("Desktop window close: no active widget, closing normally");
+                Logger.Info($"Desktop window close: widget not currently visible in Game Bar (exists={gamingXboxGameBarWidget != null}), closing normally");
                 return;
             }
 

--- a/XboxGamingBar/Data/Profile/DeleteGameProfileProperty.cs
+++ b/XboxGamingBar/Data/Profile/DeleteGameProfileProperty.cs
@@ -1,0 +1,14 @@
+using Shared.Enums;
+
+namespace XboxGamingBar.Data
+{
+    // Action trigger property. ForceSetValue(gameName) tells the helper to delete that
+    // game's per-game profile XML (ProfileManager.DeleteProfile) so a deleted profile
+    // doesn't leave an orphaned file the helper would re-apply when the game reappears.
+    internal class DeleteGameProfileProperty : WidgetProperty<string>
+    {
+        public DeleteGameProfileProperty() : base("", null, Function.DeleteGameProfile)
+        {
+        }
+    }
+}

--- a/XboxGamingBar/Data/TouchscreenEnabledProperty.cs
+++ b/XboxGamingBar/Data/TouchscreenEnabledProperty.cs
@@ -1,0 +1,16 @@
+using Shared.Enums;
+
+namespace XboxGamingBar.Data
+{
+    /// <summary>
+    /// Headless send-channel for the built-in touch screen on/off state (Quick Settings tile
+    /// only - no dedicated settings-tab control). The helper is authoritative for the persisted
+    /// value and applies it via SetupAPI device enable/disable; this just mirrors/sends the bool.
+    /// </summary>
+    internal class TouchscreenEnabledProperty : WidgetProperty<bool>
+    {
+        public TouchscreenEnabledProperty() : base(true, null, Function.TouchscreenEnabled)
+        {
+        }
+    }
+}

--- a/XboxGamingBar/Features/Debug/GamingWidget.DebugPanel.cs
+++ b/XboxGamingBar/Features/Debug/GamingWidget.DebugPanel.cs
@@ -109,7 +109,7 @@ namespace XboxGamingBar
             {
                 var cardBgBrush = new SolidColorBrush(theme.CardBackground);
                 var cardBorderBrush = new SolidColorBrush(theme.CardBorder);
-                var accentBrush = new SolidColorBrush(theme.AccentColor);
+                var accentBrush = GetThemeAccentBrush(theme);
                 var textSecondaryBrush = new SolidColorBrush(theme.TextSecondary);
 
                 // Update all Border elements (cards)
@@ -121,12 +121,57 @@ namespace XboxGamingBar
             {
                 Logger.Error($"Error applying theme to visual tree: {ex.Message}");
             }
+
+            // The Win11 theme is a structural variant of the Quick Settings tiles
+            // (bottom accent bar + Fluent icons vs background tint) and of the
+            // metrics grid (icon-over-value columns with dividers). Those are
+            // code-built, so when the Win11-ness of the active theme no longer
+            // matches what they were built for, rebuild them now (also covers the
+            // startup path when the saved theme is applied after the tiles exist).
+            try
+            {
+                if (quickSettingsInitialized && quickSettingsBuiltForWin11 != IsWin11Theme)
+                {
+                    UpdateQuickSettingsThemeBrushes();
+                    RebuildQuickSettingsTiles();
+                    UpdateQuickSettingsTileStates();
+                    RebuildMetricsGrid();
+                    Logger.Info($"Quick Settings tiles/metrics rebuilt for theme '{themeName}' (Win11={IsWin11Theme})");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error rebuilding Quick Settings for theme change: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Accent brush for a theme. The Win11 theme follows the user's live
+        /// Windows accent color (SystemAccentColorLight2) instead of the static
+        /// palette entry; every other theme uses its fixed AccentColor.
+        /// </summary>
+        private SolidColorBrush GetThemeAccentBrush(ThemeColors theme)
+        {
+            if (theme.Name == "Win11")
+            {
+                try
+                {
+                    return new SolidColorBrush((Windows.UI.Color)Application.Current.Resources["SystemAccentColorLight2"]);
+                }
+                catch
+                {
+                    // Fall through to the static fallback color
+                }
+            }
+            return new SolidColorBrush(theme.AccentColor);
         }
 
         private void ApplyThemeToVisualTree(DependencyObject parent, ThemeColors theme,
             SolidColorBrush cardBgBrush, SolidColorBrush cardBorderBrush,
             SolidColorBrush accentBrush, SolidColorBrush textSecondaryBrush)
         {
+            bool win11 = theme.Name == "Win11";
+
             int childCount = VisualTreeHelper.GetChildrenCount(parent);
             for (int i = 0; i < childCount; i++)
             {
@@ -135,13 +180,32 @@ namespace XboxGamingBar
                 // Update Border elements (cards use CardStyle with specific properties)
                 if (child is Border border)
                 {
-                    // Check if this looks like a card (has corner radius and padding typical of CardStyle)
+                    // Check if this looks like a card (has corner radius and padding typical
+                    // of CardStyle). Matches TopLeft 8 (classic CardStyle) OR 10 (after the
+                    // Win11 pass below reshaped it) so cards stay recognizable in both modes.
                     // Skip borders with LinearGradientBrush backgrounds (custom gradients for "smart" features like DGP card)
-                    if (border.CornerRadius.TopLeft == 8 && border.Padding.Left == 12 &&
+                    if ((border.CornerRadius.TopLeft == 8 || border.CornerRadius.TopLeft == 10) &&
+                        border.Padding.Left == 12 &&
                         !(border.Background is LinearGradientBrush))
                     {
                         border.Background = cardBgBrush;
                         border.BorderBrush = cardBorderBrush;
+
+                        // Win11 card geometry (fork f04f1e78): CornerRadius 8->10 and
+                        // BorderThickness 2->1; restore the CardStyle defaults when any
+                        // other theme is applied. Only flip between the two known card
+                        // signatures so borders that merely share the radius/padding but
+                        // have a different thickness are left alone.
+                        if (win11 && border.CornerRadius.TopLeft == 8 && border.BorderThickness.Left == 2)
+                        {
+                            border.CornerRadius = new CornerRadius(10);
+                            border.BorderThickness = new Thickness(1);
+                        }
+                        else if (!win11 && border.CornerRadius.TopLeft == 10 && border.BorderThickness.Left == 1)
+                        {
+                            border.CornerRadius = new CornerRadius(8);
+                            border.BorderThickness = new Thickness(2);
+                        }
                     }
                 }
 
@@ -159,6 +223,23 @@ namespace XboxGamingBar
                         else if (brush.Color.R == 160 && brush.Color.G == 160 && brush.Color.B == 160)
                         {
                             textBlock.Foreground = textSecondaryBrush;
+                        }
+                    }
+
+                    // Win11 typography (fork f04f1e78): card titles / section headers
+                    // (CardTitleStyle 18pt, CardTitleStyleCompact 20pt - the only Bold
+                    // TextBlocks at those sizes) go Bold -> SemiBold; restored when a
+                    // non-Win11 theme is applied. No XAML TextBlock ships SemiBold at
+                    // 18/20pt, so the reverse conversion can't catch innocents.
+                    if (textBlock.FontSize == 18 || textBlock.FontSize == 20)
+                    {
+                        if (win11 && textBlock.FontWeight.Weight == Windows.UI.Text.FontWeights.Bold.Weight)
+                        {
+                            textBlock.FontWeight = Windows.UI.Text.FontWeights.SemiBold;
+                        }
+                        else if (!win11 && textBlock.FontWeight.Weight == Windows.UI.Text.FontWeights.SemiBold.Weight)
+                        {
+                            textBlock.FontWeight = Windows.UI.Text.FontWeights.Bold;
                         }
                     }
                 }
@@ -1373,9 +1454,13 @@ namespace XboxGamingBar
                 var dialog = new Windows.UI.Popups.MessageDialog(
                     "This will:\n\n" +
                     "• Remove the scheduled task\n" +
-                    "• Restore original CPU Boost settings\n" +
-                    "• Restore original EPP settings\n" +
-                    "• Re-enable Legion Space service (if disabled)\n\n" +
+                    "• Restore original CPU Boost, EPP, Max/Min CPU State and Power Mode settings\n" +
+                    "• Re-enable Legion Space service (if disabled)\n" +
+                    "• Re-enable the touchscreen (if disabled)\n" +
+                    "• Release any active custom fan curve\n" +
+                    "• Stop controller emulation and clear HidHide rules\n\n" +
+                    "This does not remove drivers (PawnIO, usbip-win2, HidHide) or the deployed " +
+                    "helper copy - for a full cleanup, run Uninstall-GoTweaks.ps1 after uninstalling.\n\n" +
                     "After this, you can safely uninstall the app.",
                     "Prepare for Uninstall");
 

--- a/XboxGamingBar/Features/Labs/GamingWidget.Labs.cs
+++ b/XboxGamingBar/Features/Labs/GamingWidget.Labs.cs
@@ -160,7 +160,9 @@ namespace XboxGamingBar
 
         private void OnDAServiceStatusReceived(int status)
         {
-            // Status: 0 = Stopped/Disabled, 1 = Running, 2 = Not Found, 3 = Stopping, 4 = Starting
+            // Status reflects the startup state: 0 = Disabled (no boot auto-start; Legion Space
+            // still launchable on demand), 1 = Enabled (auto-starts at boot), 2 = Not Found.
+            // (3/4 are legacy transient codes the helper no longer sends.)
             _ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
                 if (DAServiceStatusText == null || ToggleDAServiceButton == null)
@@ -168,16 +170,16 @@ namespace XboxGamingBar
 
                 switch (status)
                 {
-                    case 0: // Stopped/Disabled
+                    case 0: // Disabled (no auto-start; still launchable on demand)
                         daServiceIsRunning = false;
-                        DAServiceStatusText.Text = "Service disabled - Legion L/R buttons disabled";
+                        DAServiceStatusText.Text = "Auto-start off - Legion Space won't run at boot (still launchable)";
                         DAServiceStatusText.Foreground = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 0, 200, 83)); // Green
                         ToggleDAServiceButton.Content = "Enable";
                         ToggleDAServiceButton.IsEnabled = true;
                         break;
-                    case 1: // Running
+                    case 1: // Enabled (auto-starts at boot)
                         daServiceIsRunning = true;
-                        DAServiceStatusText.Text = "Service running - Legion Space controls buttons";
+                        DAServiceStatusText.Text = "Auto-start on - Legion Space runs at boot";
                         DAServiceStatusText.Foreground = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 255, 170, 0)); // Orange
                         ToggleDAServiceButton.Content = "Disable";
                         ToggleDAServiceButton.IsEnabled = true;

--- a/XboxGamingBar/Features/Lifecycle/GamingWidget.Lifecycle.cs
+++ b/XboxGamingBar/Features/Lifecycle/GamingWidget.Lifecycle.cs
@@ -89,6 +89,13 @@ namespace XboxGamingBar
             App.UnregisterActiveGamingWidget(this);
             Logger.Info("GamingWidget instance unregistered.");
 
+            // Detach this instance's pipe handlers. The active-instance guards inside those
+            // handlers already make a stale instance's callbacks a no-op, but leaving them
+            // subscribed across repeated Game-Bar-driven instance recreations lets dead
+            // GamingWidget instances pile up on the static App.PipeMessageReceived event.
+            App.PipeMessageReceived -= PipeClient_MessageReceived;
+            App.PipeDisconnected -= PipeClient_Disconnected;
+
             // Unsubscribe from Lossless Scaling property changes
             if (losslessScalingInstalled != null)
             {

--- a/XboxGamingBar/Features/Navigation/GamingWidget.Navigation.cs
+++ b/XboxGamingBar/Features/Navigation/GamingWidget.Navigation.cs
@@ -273,7 +273,7 @@ namespace XboxGamingBar
 
             var cardBgBrush = new SolidColorBrush(theme.CardBackground);
             var cardBorderBrush = new SolidColorBrush(theme.CardBorder);
-            var accentBrush = new SolidColorBrush(theme.AccentColor);
+            var accentBrush = GetThemeAccentBrush(theme); // Win11 follows the live Windows accent
             var textSecondaryBrush = new SolidColorBrush(theme.TextSecondary);
 
             // Apply to all scroll viewers (only visible ones will have loaded content)

--- a/XboxGamingBar/Features/Profile/GamingWidget.ProfileDeletion.cs
+++ b/XboxGamingBar/Features/Profile/GamingWidget.ProfileDeletion.cs
@@ -154,17 +154,63 @@ namespace XboxGamingBar
                 Logger.Info($"Deleted per-game power split setting for {gameName}");
             }
 
-            if (profileDeleted)
+            // Also delete the game's controller profile so "delete" is a clean reset of the
+            // whole game. Without this, the per-game controller remaps/lighting (stored in a
+            // separate ControllerProfile_Game_<name> container) and the "disabled" preference
+            // survive the delete and reappear the next time the game is detected.
+            bool controllerDeleted = false;
+            string controllerKey = $"ControllerProfile_Game_{gameName}";
+            if (settings.Containers.ContainsKey(controllerKey))
             {
-                // If we deleted the current game's profile, disable per-game toggle
-                if (gameName == currentGameName && PerGameProfileToggle?.IsOn == true)
+                settings.DeleteContainer(controllerKey);
+                Logger.Info($"Deleted controller profile for {gameName}");
+                controllerDeleted = true;
+            }
+            string controllerDisabledKey = $"ControllerProfileDisabled_{gameName}";
+            if (settings.Values.ContainsKey(controllerDisabledKey))
+            {
+                settings.Values.Remove(controllerDisabledKey);
+            }
+
+            // Tell the helper to delete its per-game profile XML (profiles/<exe>.xml).
+            // The helper implements this (ProfileManager.DeleteProfile) but the widget never
+            // triggered it, so a deleted profile left an orphaned XML the helper could still
+            // match and re-apply when the game reappeared. ForceSetValue so a repeat delete of
+            // the same name still sends (the trigger value would otherwise dedupe).
+            deleteGameProfile?.ForceSetValue(gameName);
+            Logger.Info($"Sent DeleteGameProfile to helper for {gameName}");
+
+            if (profileDeleted || controllerDeleted)
+            {
+                // If we deleted the current game's profile(s), reset its per-game toggles so the
+                // UI falls back to the global profiles instead of pointing at deleted containers.
+                if (gameName == currentGameName)
                 {
-                    Logger.Info($"Deleted profile for current game {gameName}, disabling per-game toggle");
-                    PerGameProfileToggle.IsOn = false;
+                    if (PerGameProfileToggle?.IsOn == true)
+                    {
+                        Logger.Info($"Deleted profile for current game {gameName}, disabling per-game toggle");
+                        PerGameProfileToggle.IsOn = false;
+                    }
+                    if (LegionControllerProfileToggle?.IsOn == true)
+                    {
+                        Logger.Info($"Deleted controller profile for current game {gameName}, disabling per-game controller toggle");
+                        LegionControllerProfileToggle.IsOn = false;
+                    }
+
+                    // The controller toggle-off handler re-writes the "disabled" preference;
+                    // remove it again so a deleted game returns to a pristine (global) state.
+                    if (settings.Values.ContainsKey(controllerDisabledKey))
+                    {
+                        settings.Values.Remove(controllerDisabledKey);
+                    }
                 }
 
-                // Refresh the display
+                // Refresh the display and the saved-controller-profiles list (if expanded).
                 UpdateProfileDisplay();
+                if (isSavedProfilesExpanded)
+                {
+                    RefreshSavedProfilesList();
+                }
             }
         }
 

--- a/XboxGamingBar/Features/QuickSettings/GamingWidget.QuickSettings.Actions.cs
+++ b/XboxGamingBar/Features/QuickSettings/GamingWidget.QuickSettings.Actions.cs
@@ -154,6 +154,9 @@ namespace XboxGamingBar
                             case "LegionTouchpad":
                                 ToggleLegionTouchpad();
                                 break;
+                            case "Touchscreen":
+                                ToggleTouchscreen();
+                                break;
                             case "LegionLightMode":
                                 CycleLegionLightMode();
                                 break;
@@ -1170,6 +1173,16 @@ namespace XboxGamingBar
                 bool newValue = !legionTouchpadEnabled.Value;
                 legionTouchpadEnabled.SetValue(newValue);
                 Logger.Info($"Legion Touchpad toggled to {newValue}");
+            }
+        }
+
+        private void ToggleTouchscreen()
+        {
+            if (legionGoDetected?.Value == true && touchscreenEnabled != null)
+            {
+                bool newValue = !touchscreenEnabled.Value;
+                touchscreenEnabled.SetValue(newValue);
+                Logger.Info($"Touchscreen toggled to {newValue}");
             }
         }
 

--- a/XboxGamingBar/Features/QuickSettings/GamingWidget.QuickSettings.Grid.cs
+++ b/XboxGamingBar/Features/QuickSettings/GamingWidget.QuickSettings.Grid.cs
@@ -449,7 +449,8 @@ namespace XboxGamingBar
             // Skip Legion tiles if not detected
             if ((tile.Id == "LegionTouchpad" || tile.Id == "LegionLightMode" ||
                  tile.Id == "LegionDesktopControls" || tile.Id == "LegionRemapControls" ||
-                 tile.Id == "LegionChargeLimit" || tile.Id == "LegionPowerLight") &&
+                 tile.Id == "LegionChargeLimit" || tile.Id == "LegionPowerLight" ||
+                 tile.Id == "Touchscreen") &&
                 (legionGoDetected?.Value != true))
             {
                 return true;

--- a/XboxGamingBar/Features/QuickSettings/GamingWidget.QuickSettings.Metrics.cs
+++ b/XboxGamingBar/Features/QuickSettings/GamingWidget.QuickSettings.Metrics.cs
@@ -382,18 +382,58 @@ namespace XboxGamingBar
                 return;
             }
 
-            // Create columns for each selected metric
-            foreach (var _ in selectedMetrics)
+            // Win11 theme (fork commits 77a24806 + e1cb6ef9): icon centered on top,
+            // value below the icon, gray label below the value, with a thin
+            // translucent divider between metrics. Classic: inline icon+value row
+            // with the label underneath, no dividers.
+            bool win11 = IsWin11Theme;
+
+            // Restyle the containing rows for the active theme (these are static
+            // XAML elements with hardcoded classic colors, untouched by the card
+            // walker because their CornerRadius is 12).
+            var rowBg = new SolidColorBrush(win11
+                ? Windows.UI.Color.FromArgb(255, 0x35, 0x39, 0x3F)   // #35393F flat neutral
+                : Windows.UI.Color.FromArgb(255, 0x1A, 0x1C, 0x1E)); // #1A1C1E classic
+            var rowBorder = new SolidColorBrush(win11
+                ? Windows.UI.Color.FromArgb(0x22, 255, 255, 255)     // #22FFFFFF hairline
+                : Windows.UI.Color.FromArgb(255, 0x50, 0x55, 0x5C)); // #50555C classic
+            QuickMetricsRow.Background = rowBg;
+            QuickMetricsRow.BorderBrush = rowBorder;
+            if (PanelBrightnessRow != null)
             {
+                PanelBrightnessRow.Background = rowBg;
+                PanelBrightnessRow.BorderBrush = rowBorder;
+            }
+
+            // Create columns: one star column per metric; in Win11 also a thin Auto
+            // divider column between each pair of metrics.
+            for (int c = 0; c < selectedMetrics.Count; c++)
+            {
+                if (win11 && c > 0) QuickMetricsGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
                 QuickMetricsGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
             }
 
             // Create UI for each selected metric
-            int colIndex = 0;
-            foreach (var metricType in selectedMetrics)
+            int gridCol = 0;
+            for (int i = 0; i < selectedMetrics.Count; i++)
             {
+                var metricType = selectedMetrics[i];
                 if (!metricDefinitions.TryGetValue(metricType, out var info))
                     continue;
+
+                if (win11 && i > 0)
+                {
+                    // Thin translucent divider between metrics.
+                    var divider = new Border
+                    {
+                        Width = 1,
+                        Background = new SolidColorBrush(Windows.UI.Color.FromArgb(0x33, 0xFF, 0xFF, 0xFF)),
+                        Margin = new Thickness(0, 2, 0, 2)
+                    };
+                    Grid.SetColumn(divider, gridCol);
+                    QuickMetricsGrid.Children.Add(divider);
+                    gridCol++;
+                }
 
                 // Create metric panel
                 var panel = new StackPanel
@@ -402,54 +442,94 @@ namespace XboxGamingBar
                     VerticalAlignment = VerticalAlignment.Center
                 };
 
-                // Value row (icon + value)
-                var valueRow = new StackPanel
+                if (win11)
                 {
-                    Orientation = Orientation.Horizontal,
-                    HorizontalAlignment = HorizontalAlignment.Center
-                };
+                    // Icon-over-value-over-label layout. Font sizes match the Win11
+                    // Quick Settings tiles (icon 21 / value 12 / label 13-14).
+                    var icon = new FontIcon
+                    {
+                        Glyph = info.Glyph,
+                        FontSize = 21,
+                        Foreground = new SolidColorBrush((Windows.UI.Color)Application.Current.Resources["SystemAccentColorLight2"]),
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        Margin = new Thickness(0, 0, 0, 3)
+                    };
 
-                var icon = new FontIcon
+                    var valueText = new TextBlock
+                    {
+                        Text = "--",
+                        FontSize = 12,
+                        FontWeight = Windows.UI.Text.FontWeights.SemiBold,
+                        Foreground = new SolidColorBrush(Windows.UI.Colors.White),
+                        HorizontalAlignment = HorizontalAlignment.Center
+                    };
+                    info.ValueTextBlock = valueText;
+
+                    var labelText = new TextBlock
+                    {
+                        Text = info.Label,
+                        FontSize = qsColumnCount == 4 ? 13 : 14,
+                        Foreground = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 136, 136, 136)), // #888888
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        Margin = new Thickness(0, 2, 0, 0)
+                    };
+                    info.LabelTextBlock = labelText;
+
+                    panel.Children.Add(icon);
+                    panel.Children.Add(valueText);
+                    panel.Children.Add(labelText);
+                }
+                else
                 {
-                    Glyph = info.Glyph,
-                    // Bumped one step for readability (paired inline with the value text below).
-                    FontSize = 16,
-                    Foreground = new SolidColorBrush((Windows.UI.Color)Application.Current.Resources["SystemAccentColorLight2"]),
-                    Margin = new Thickness(0, 0, 4, 0),
-                    VerticalAlignment = VerticalAlignment.Center
-                };
+                    // Value row (icon + value)
+                    var valueRow = new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        HorizontalAlignment = HorizontalAlignment.Center
+                    };
 
-                var valueText = new TextBlock
-                {
-                    Text = "--",
-                    FontSize = 16,
-                    FontWeight = Windows.UI.Text.FontWeights.SemiBold,
-                    Foreground = new SolidColorBrush(Windows.UI.Colors.White),
-                    VerticalAlignment = VerticalAlignment.Center
-                };
-                info.ValueTextBlock = valueText;
+                    var icon = new FontIcon
+                    {
+                        Glyph = info.Glyph,
+                        // Bumped one step for readability (paired inline with the value text below).
+                        FontSize = 16,
+                        Foreground = new SolidColorBrush((Windows.UI.Color)Application.Current.Resources["SystemAccentColorLight2"]),
+                        Margin = new Thickness(0, 0, 4, 0),
+                        VerticalAlignment = VerticalAlignment.Center
+                    };
 
-                valueRow.Children.Add(icon);
-                valueRow.Children.Add(valueText);
+                    var valueText = new TextBlock
+                    {
+                        Text = "--",
+                        FontSize = 16,
+                        FontWeight = Windows.UI.Text.FontWeights.SemiBold,
+                        Foreground = new SolidColorBrush(Windows.UI.Colors.White),
+                        VerticalAlignment = VerticalAlignment.Center
+                    };
+                    info.ValueTextBlock = valueText;
 
-                // Label
-                var labelText = new TextBlock
-                {
-                    Text = info.Label,
-                    // Bumped one step for readability.
-                    FontSize = 12,
-                    Foreground = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 136, 136, 136)), // #888888
-                    HorizontalAlignment = HorizontalAlignment.Center
-                };
-                info.LabelTextBlock = labelText;
+                    valueRow.Children.Add(icon);
+                    valueRow.Children.Add(valueText);
 
-                panel.Children.Add(valueRow);
-                panel.Children.Add(labelText);
+                    // Label
+                    var labelText = new TextBlock
+                    {
+                        Text = info.Label,
+                        // Bumped one step for readability.
+                        FontSize = 12,
+                        Foreground = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 136, 136, 136)), // #888888
+                        HorizontalAlignment = HorizontalAlignment.Center
+                    };
+                    info.LabelTextBlock = labelText;
 
-                Grid.SetColumn(panel, colIndex);
+                    panel.Children.Add(valueRow);
+                    panel.Children.Add(labelText);
+                }
+
+                Grid.SetColumn(panel, gridCol);
                 QuickMetricsGrid.Children.Add(panel);
 
-                colIndex++;
+                gridCol++;
             }
 
             // Show the row if we have metrics

--- a/XboxGamingBar/Features/QuickSettings/GamingWidget.QuickSettings.TileStates.cs
+++ b/XboxGamingBar/Features/QuickSettings/GamingWidget.QuickSettings.TileStates.cs
@@ -51,6 +51,10 @@ namespace XboxGamingBar
         {
             if (QuickSettingsTilesContainer == null) return;
 
+            // Record which structural style this build uses so ApplyTheme knows
+            // when a Win11 <-> classic switch requires a rebuild.
+            quickSettingsBuiltForWin11 = IsWin11Theme;
+
             QuickSettingsTilesContainer.Children.Clear();
 
             // Get tiles to display - in edit mode show all (including hidden), otherwise only visible
@@ -113,8 +117,12 @@ namespace XboxGamingBar
         /// </summary>
         private Button CreateTileButton(TileDefinition tile)
         {
-            // Action tiles get a distinct background color
-            var bgBrush = tile.IsAction
+            bool win11 = IsWin11Theme;
+
+            // Classic: action tiles get a distinct background color.
+            // Win11 (fork 77a24806): every tile shares the same neutral background -
+            // only the subtitle + bottom accent bar color is distinct.
+            var bgBrush = (!win11 && tile.IsAction)
                 ? new SolidColorBrush(Windows.UI.Color.FromArgb(255, 37, 32, 48))  // Dark purple for action tiles
                 : tileOffBrush;
 
@@ -134,24 +142,45 @@ namespace XboxGamingBar
                 HorizontalContentAlignment = HorizontalAlignment.Stretch
             };
 
+            if (win11)
+            {
+                // Compact Win11 tile geometry (fork values; the shared
+                // QuickSettingsTileStyle keeps its classic Padding/MinHeight, so
+                // override per-button here where it's rebuilt on theme change).
+                // Slightly taller at 4 columns - narrower tiles read as too squat.
+                button.Padding = qsColumnCount == 4 ? new Thickness(10, 9, 10, 9) : new Thickness(10, 7, 10, 7);
+                button.MinHeight = 54;
+            }
+
             // Stretch so the state-text Canvas below gets the full tile width to scroll in
             // (otherwise the StackPanel sizes to its widest child — usually the centered label —
             // and marquees scroll in a narrow strip). Icon and label stay Center-aligned per-child
             // so the tile still looks centered.
             var content = new StackPanel { HorizontalAlignment = HorizontalAlignment.Stretch };
 
-            content.Children.Add(new FontIcon
+            // Win11: smaller icon in Segoe Fluent Icons (Windows 11's icon font)
+            // instead of the FontIcon default of Segoe MDL2 Assets. Icon and tile
+            // name stay white always in Win11 - the active-tile accent signal lives
+            // in the state text color and the bottom accent bar (SetTileAccentBar).
+            var icon = new FontIcon
             {
                 Glyph = tile.Glyph,
-                FontSize = 28,
+                FontSize = win11 ? 21 : 28,
                 HorizontalAlignment = HorizontalAlignment.Center
-            });
+            };
+            if (win11)
+            {
+                icon.FontFamily = new FontFamily("Segoe Fluent Icons");
+            }
+            content.Children.Add(icon);
+            tile.IconElement = icon;
 
             content.Children.Add(new TextBlock
             {
                 Text = tile.Name,
-                FontSize = 14,
-                Margin = new Thickness(0, 8, 0, 0),
+                // Win11: slightly smaller at 4 columns, where tiles are narrowest.
+                FontSize = win11 ? (qsColumnCount == 4 ? 13 : 14) : 14,
+                Margin = win11 ? new Thickness(0, 4, 0, 0) : new Thickness(0, 8, 0, 0),
                 HorizontalAlignment = HorizontalAlignment.Center,
                 TextWrapping = TextWrapping.Wrap,
                 TextAlignment = TextAlignment.Center
@@ -161,9 +190,9 @@ namespace XboxGamingBar
             var stateText = new TextBlock
             {
                 Text = tile.IsAction ? "Action" : "Off",
-                FontSize = 13,
+                FontSize = win11 ? 12 : 13,
                 Foreground = tile.IsAction
-                    ? new SolidColorBrush(Windows.UI.Color.FromArgb(255, 180, 150, 200))  // Light purple for action
+                    ? (SolidColorBrush)(win11 ? tileActionBrush : new SolidColorBrush(Windows.UI.Color.FromArgb(255, 180, 150, 200)))  // Light purple for action
                     : new SolidColorBrush(Windows.UI.Color.FromArgb(255, 136, 136, 136)),
                 HorizontalAlignment = HorizontalAlignment.Left,
                 VerticalAlignment = VerticalAlignment.Center,
@@ -178,13 +207,14 @@ namespace XboxGamingBar
             var transform = new TranslateTransform { X = 0 };
             stateText.RenderTransform = transform;
 
+            double canvasHeight = win11 ? 15 : 18;
             var canvas = new Canvas
             {
-                Height = 18,
-                Margin = new Thickness(0, 2, 0, 0),
+                Height = canvasHeight,
+                Margin = win11 ? new Thickness(0, 1, 0, 0) : new Thickness(0, 2, 0, 0),
                 HorizontalAlignment = HorizontalAlignment.Stretch
             };
-            canvas.Clip = new RectangleGeometry { Rect = new Windows.Foundation.Rect(0, 0, 0, 18) };
+            canvas.Clip = new RectangleGeometry { Rect = new Windows.Foundation.Rect(0, 0, 0, canvasHeight) };
             canvas.Children.Add(stateText);
 
             // Keep the clip rect in sync with the actual laid-out width so scroll
@@ -193,7 +223,7 @@ namespace XboxGamingBar
             {
                 if (e.NewSize.Width > 0)
                 {
-                    canvas.Clip = new RectangleGeometry { Rect = new Windows.Foundation.Rect(0, 0, e.NewSize.Width, 18) };
+                    canvas.Clip = new RectangleGeometry { Rect = new Windows.Foundation.Rect(0, 0, e.NewSize.Width, canvasHeight) };
                     // Re-evaluate scroll state now that the available width changed
                     UpdateTileScrollAnimation(tile);
                 }
@@ -204,6 +234,37 @@ namespace XboxGamingBar
             tile.StateTextCanvas = canvas;
             tile.StateTextTransform = transform;
 
+            if (win11)
+            {
+                // Active-tile accent bar (Win11 only): a small rounded bar centered
+                // along the bottom edge, ~1/4 of the tile's own width - width tracks
+                // the button's actual laid-out size via SizeChanged. Muted gray when
+                // the tile is off - see SetTileAccentBar. Action tiles get
+                // tileActionBrush immediately.
+                var accentBar = new Border
+                {
+                    Height = 3,
+                    CornerRadius = new CornerRadius(1.5),
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Margin = new Thickness(0, 5, 0, -3),
+                    Background = tile.IsAction ? tileActionBrush : tileBarOffBrush
+                };
+                content.Children.Add(accentBar);
+                tile.AccentBar = accentBar;
+
+                button.SizeChanged += (s, e) =>
+                {
+                    if (e.NewSize.Width > 0)
+                    {
+                        accentBar.Width = e.NewSize.Width * 0.25;
+                    }
+                };
+            }
+            else
+            {
+                tile.AccentBar = null;
+            }
+
             button.Content = content;
             button.Click += QuickSettingsTile_Click;
 
@@ -211,6 +272,18 @@ namespace XboxGamingBar
             tile.StateText = stateText;
 
             return button;
+        }
+
+        /// <summary>
+        /// Win11 theme only: sets a tile's bottom accent bar to the live Windows
+        /// accent color when on, or a muted gray (same tone as the off state text)
+        /// when off. No-op in classic themes (AccentBar is null). Call with the same
+        /// boolean condition used for that tile's StateText.Foreground.
+        /// </summary>
+        private void SetTileAccentBar(TileDefinition tile, bool isOn)
+        {
+            if (tile?.AccentBar == null) return;
+            tile.AccentBar.Background = isOn ? tileAccentBrush : tileBarOffBrush;
         }
 
         /// <summary>
@@ -331,6 +404,11 @@ namespace XboxGamingBar
 
             try
             {
+                // Win11 theme: state is presented on the bottom accent bar (and for
+                // TDP/Power/EPP as a fixed severity color there) while backgrounds
+                // stay neutral. Classic themes: state tints the tile background.
+                bool win11 = IsWin11Theme;
+
                 var accentForeground = new SolidColorBrush((Windows.UI.Color)Application.Current.Resources["SystemAccentColorLight2"]);
                 var offForeground = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 136, 136, 136));
 
@@ -341,6 +419,9 @@ namespace XboxGamingBar
                     int selectedIndex = TDPModeComboBox?.SelectedIndex ?? 0;
                     string modeText;
                     SolidColorBrush tdpModeBrush;
+                    // Win11 theme: fixed severity color for the bottom accent bar
+                    // (green=Quiet, blue=Balanced, red=Performance, purple=Custom).
+                    SolidColorBrush tdpModeColor;
 
                     // Use custom presets if enabled
                     if (useCustomTDPPresets && tdpPresets != null && tdpPresets.Count > 0)
@@ -355,15 +436,19 @@ namespace XboxGamingBar
                             {
                                 case 1: // Quiet - Desaturated Blue
                                     tdpModeBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 35, 45, 60));
+                                    tdpModeColor = tileSeverityGreenBrush;
                                     break;
                                 case 2: // Balanced - Grey
                                     tdpModeBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 50, 50, 55));
+                                    tdpModeColor = tileSeverityBlueBrush;
                                     break;
                                 case 3: // Performance - Desaturated Red
                                     tdpModeBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 60, 40, 40));
+                                    tdpModeColor = tileSeverityRedBrush;
                                     break;
                                 default: // Custom preset (no LegionModeValue) - Purple
                                     tdpModeBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 50, 42, 58));
+                                    tdpModeColor = tileSeverityPurpleBrush;
                                     break;
                             }
                         }
@@ -373,6 +458,7 @@ namespace XboxGamingBar
                             int currentTdp = (int)(TDPSlider?.Value ?? 15);
                             modeText = $"Custom ({currentTdp}W)";
                             tdpModeBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 50, 42, 58));
+                            tdpModeColor = tileSeverityPurpleBrush;
                         }
                     }
                     else
@@ -395,30 +481,46 @@ namespace XboxGamingBar
                             case 1: // Quiet - Desaturated Blue
                                 modeText = isLegion ? "Quiet" : $"Quiet ({genericTDPValues[0]}W)";
                                 tdpModeBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 35, 45, 60));
+                                tdpModeColor = tileSeverityGreenBrush;
                                 break;
                             case 2: // Balanced - Grey
                                 modeText = isLegion ? "Balanced" : $"Balanced ({genericTDPValues[1]}W)";
                                 tdpModeBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 50, 50, 55));
+                                tdpModeColor = tileSeverityBlueBrush;
                                 break;
                             case 3: // Performance - Desaturated Red
                                 modeText = isLegion ? "Performance" : $"Perf ({genericTDPValues[2]}W)";
                                 tdpModeBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 60, 40, 40));
+                                tdpModeColor = tileSeverityRedBrush;
                                 break;
                             case 255: // Custom - Desaturated Purple
                                 int currentTdp = (int)(TDPSlider?.Value ?? 15);
                                 modeText = $"Custom ({currentTdp}W)";
                                 tdpModeBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 50, 42, 58));
+                                tdpModeColor = tileSeverityPurpleBrush;
                                 break;
                             default:
                                 modeText = isLegion ? "Balanced" : $"Balanced ({genericTDPValues[1]}W)";
                                 tdpModeBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 50, 50, 55));
+                                tdpModeColor = tileSeverityBlueBrush;
                                 break;
                         }
                     }
 
                     tdpTile.StateText.Text = modeText;
-                    tdpTile.StateText.Foreground = accentForeground;
-                    tdpTile.TileButton.Background = tdpModeBrush;
+                    if (win11)
+                    {
+                        // Background/border stay neutral like every other tile; the
+                        // bottom bar carries the severity color, state text stays gray.
+                        tdpTile.StateText.Foreground = offForeground;
+                        if (tdpTile.AccentBar != null) tdpTile.AccentBar.Background = tdpModeColor;
+                        tdpTile.TileButton.Background = tileOffBrush;
+                    }
+                    else
+                    {
+                        tdpTile.StateText.Foreground = accentForeground;
+                        tdpTile.TileButton.Background = tdpModeBrush;
+                    }
                 }
 
                 // AutoTDP tile
@@ -429,6 +531,7 @@ namespace XboxGamingBar
                     string stateText = enabled ? $"{targetFps} FPS" : "Off";
                     autoTdpTile.StateText.Text = stateText;
                     autoTdpTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                    SetTileAccentBar(autoTdpTile, enabled);
                     autoTdpTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                 }
 
@@ -447,13 +550,25 @@ namespace XboxGamingBar
                         profileName = currentDefaultGameProfile?.GameName ?? gameName;
                         profileTile.StateText.Text = profileName;
                         profileTile.StateText.Foreground = accentForeground;
-                        profileTile.TileButton.Background = tileDefaultProfileBrush;
+                        if (win11)
+                        {
+                            // Win11: background stays neutral; the "default game
+                            // profile" special state moves to a purple bottom bar
+                            // (distinct from the accent used for a plain per-game hit).
+                            if (profileTile.AccentBar != null) profileTile.AccentBar.Background = tileSeverityPurpleBrush;
+                            profileTile.TileButton.Background = tileOffBrush;
+                        }
+                        else
+                        {
+                            profileTile.TileButton.Background = tileDefaultProfileBrush;
+                        }
                     }
                     else
                     {
                         profileName = perGame ? gameName : "Global";
                         profileTile.StateText.Text = profileName;
                         profileTile.StateText.Foreground = perGame ? accentForeground : offForeground;
+                        SetTileAccentBar(profileTile, perGame);
                         profileTile.TileButton.Background = perGame ? tileOnBrush : tileOffBrush;
                     }
 
@@ -481,25 +596,37 @@ namespace XboxGamingBar
                         }
                         overlayTile.StateText.Text = levelText;
                         overlayTile.StateText.Foreground = level > 0 ? accentForeground : offForeground;
+                        SetTileAccentBar(overlayTile, level > 0);
                         overlayTile.TileButton.Background = level > 0 ? tileOnBrush : tileOffBrush;
                     }
                 }
 
-                // Power Mode tile
+                // Power Mode tile - Win11: background/border stay neutral; the
+                // bottom bar carries a fixed severity color per mode.
                 if (qsTileMap.TryGetValue("PowerMode", out var powerModeTile) && powerModeTile.TileButton != null)
                 {
                     int mode = osPowerMode?.Value ?? 1;
                     string modeText;
+                    SolidColorBrush powerModeColor;
                     switch (mode)
                     {
-                        case 0: modeText = "Efficiency"; break;
-                        case 1: modeText = "Balanced"; break;
-                        case 2: modeText = "Performance"; break;
-                        default: modeText = "Balanced"; break;
+                        case 0: modeText = "Efficiency"; powerModeColor = tileSeverityGreenBrush; break;
+                        case 1: modeText = "Balanced"; powerModeColor = tileSeverityBlueBrush; break;
+                        case 2: modeText = "Performance"; powerModeColor = tileSeverityRedBrush; break;
+                        default: modeText = "Balanced"; powerModeColor = tileSeverityBlueBrush; break;
                     }
                     powerModeTile.StateText.Text = modeText;
-                    powerModeTile.StateText.Foreground = mode != 1 ? accentForeground : offForeground;
-                    powerModeTile.TileButton.Background = mode == 2 ? tileOnBrush : (mode == 0 ? tileActiveBrush : tileOffBrush);
+                    if (win11)
+                    {
+                        powerModeTile.StateText.Foreground = offForeground;
+                        if (powerModeTile.AccentBar != null) powerModeTile.AccentBar.Background = powerModeColor;
+                        powerModeTile.TileButton.Background = tileOffBrush;
+                    }
+                    else
+                    {
+                        powerModeTile.StateText.Foreground = mode != 1 ? accentForeground : offForeground;
+                        powerModeTile.TileButton.Background = mode == 2 ? tileOnBrush : (mode == 0 ? tileActiveBrush : tileOffBrush);
+                    }
                 }
 
                 // FPS Limit tile
@@ -509,6 +636,7 @@ namespace XboxGamingBar
                     string limitText = limit == 0 ? "Off" : $"{limit}";
                     fpsLimitTile.StateText.Text = limitText;
                     fpsLimitTile.StateText.Foreground = limit > 0 ? accentForeground : offForeground;
+                    SetTileAccentBar(fpsLimitTile, limit > 0);
                     fpsLimitTile.TileButton.Background = limit > 0 ? tileOnBrush : tileOffBrush;
                 }
 
@@ -518,6 +646,7 @@ namespace XboxGamingBar
                     string currentRes = resolution?.Value ?? "1920x1080";
                     resTile.StateText.Text = currentRes;
                     resTile.StateText.Foreground = accentForeground;
+                    SetTileAccentBar(resTile, true);
                     resTile.TileButton.Background = tileOffBrush;
                 }
 
@@ -528,6 +657,7 @@ namespace XboxGamingBar
                     bool isPortrait = (displayOrientation?.Value ?? 0) == 1 || (displayOrientation?.Value ?? 0) == 3;
                     rotationTile.StateText.Text = orientationText;
                     rotationTile.StateText.Foreground = isPortrait ? accentForeground : offForeground;
+                    SetTileAccentBar(rotationTile, isPortrait);
                     rotationTile.TileButton.Background = isPortrait ? tileOnBrush : tileOffBrush;
                 }
 
@@ -538,6 +668,7 @@ namespace XboxGamingBar
                     bool enabled = hdrEnabled?.Value ?? false;
                     hdrTile.StateText.Text = !supported ? "N/A" : (enabled ? "On" : "Off");
                     hdrTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                    SetTileAccentBar(hdrTile, enabled);
                     hdrTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                 }
 
@@ -547,6 +678,7 @@ namespace XboxGamingBar
                     bool enabled = losslessScalingEnabled?.Value ?? false;
                     lsTile.StateText.Text = enabled ? "On" : "Off";
                     lsTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                    SetTileAccentBar(lsTile, enabled);
                     lsTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                 }
 
@@ -557,6 +689,7 @@ namespace XboxGamingBar
                     bool enabled = amdImageSharpeningEnabled?.Value ?? false;
                     risTile.StateText.Text = !supported ? "N/A" : (enabled ? "On" : "Off");
                     risTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                    SetTileAccentBar(risTile, enabled);
                     risTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                 }
 
@@ -567,6 +700,7 @@ namespace XboxGamingBar
                     bool enabled = amdFluidMotionFrameEnabled?.Value ?? false;
                     afmfTile.StateText.Text = !supported ? "N/A" : (enabled ? "On" : "Off");
                     afmfTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                    SetTileAccentBar(afmfTile, enabled);
                     afmfTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                 }
 
@@ -577,6 +711,7 @@ namespace XboxGamingBar
                     bool enabled = amdRadeonSuperResolutionEnabled?.Value ?? false;
                     rsrTile.StateText.Text = !supported ? "N/A" : (enabled ? "On" : "Off");
                     rsrTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                    SetTileAccentBar(rsrTile, enabled);
                     rsrTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                 }
 
@@ -587,6 +722,7 @@ namespace XboxGamingBar
                     bool enabled = amdRadeonAntiLagEnabled?.Value ?? false;
                     antiLagTile.StateText.Text = !supported ? "N/A" : (enabled ? "On" : "Off");
                     antiLagTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                    SetTileAccentBar(antiLagTile, enabled);
                     antiLagTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                 }
 
@@ -597,6 +733,7 @@ namespace XboxGamingBar
                     bool enabled = amdRadeonChillEnabled?.Value ?? false;
                     chillTile.StateText.Text = !supported ? "N/A" : (enabled ? "On" : "Off");
                     chillTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                    SetTileAccentBar(chillTile, enabled);
                     chillTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                 }
 
@@ -606,34 +743,72 @@ namespace XboxGamingBar
                     bool enabled = cpuBoost?.Value ?? false;
                     boostTile.StateText.Text = enabled ? "On" : "Off";
                     boostTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                    SetTileAccentBar(boostTile, enabled);
                     boostTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                 }
 
-                // EPP tile
+                // EPP tile - Win11: background/border stay neutral; the bottom bar
+                // carries a fixed severity color banded around the 0/30/80/100
+                // anchors: 0 = gray (matches "off"), ~1-55 = green, ~56-90 = blue,
+                // ~91-100 = red.
                 if (qsTileMap.TryGetValue("EPP", out var eppTile) && eppTile.TileButton != null)
                 {
                     int eppValue = (int)(cpuEPP?.Value ?? 0);
                     eppTile.StateText.Text = $"{eppValue}%";
-                    eppTile.StateText.Foreground = accentForeground;
-                    eppTile.TileButton.Background = eppValue > 50 ? tileActiveBrush : tileOffBrush;
+                    if (win11)
+                    {
+                        SolidColorBrush eppColor;
+                        if (eppValue <= 0) eppColor = offForeground;
+                        else if (eppValue <= 55) eppColor = tileSeverityGreenBrush;
+                        else if (eppValue <= 90) eppColor = tileSeverityBlueBrush;
+                        else eppColor = tileSeverityRedBrush;
+                        eppTile.StateText.Foreground = offForeground;
+                        if (eppTile.AccentBar != null) eppTile.AccentBar.Background = eppColor;
+                        eppTile.TileButton.Background = tileOffBrush;
+                    }
+                    else
+                    {
+                        eppTile.StateText.Foreground = accentForeground;
+                        eppTile.TileButton.Background = eppValue > 50 ? tileActiveBrush : tileOffBrush;
+                    }
                 }
 
-                // Keyboard trigger tile
+                // Keyboard trigger tile - Win11: action-colored subtitle + bar (it
+                // always fires an action, it doesn't toggle); background stays
+                // the same neutral as every other tile.
                 if (qsTileMap.TryGetValue("Keyboard", out var keyboardTile) && keyboardTile.TileButton != null)
                 {
                     keyboardTile.StateText.Text = "Open";
-                    keyboardTile.StateText.Foreground = accentForeground;
-                    keyboardTile.TileButton.Background = tileTriggerBrush;
+                    if (win11)
+                    {
+                        keyboardTile.StateText.Foreground = tileActionBrush;
+                        if (keyboardTile.AccentBar != null) keyboardTile.AccentBar.Background = tileActionBrush;
+                        keyboardTile.TileButton.Background = tileOffBrush;
+                    }
+                    else
+                    {
+                        keyboardTile.StateText.Foreground = accentForeground;
+                        keyboardTile.TileButton.Background = tileTriggerBrush;
+                    }
                 }
 
-                // Custom shortcut tiles
+                // Custom shortcut tiles - Win11: same action-colored treatment as Keyboard.
                 foreach (var shortcutTile in qsCustomShortcuts)
                 {
                     if (shortcutTile.TileButton != null && shortcutTile.StateText != null)
                     {
                         shortcutTile.StateText.Text = shortcutTile.CustomShortcut ?? "Run";
-                        shortcutTile.StateText.Foreground = accentForeground;
-                        shortcutTile.TileButton.Background = tileTriggerBrush;
+                        if (win11)
+                        {
+                            shortcutTile.StateText.Foreground = tileActionBrush;
+                            if (shortcutTile.AccentBar != null) shortcutTile.AccentBar.Background = tileActionBrush;
+                            shortcutTile.TileButton.Background = tileOffBrush;
+                        }
+                        else
+                        {
+                            shortcutTile.StateText.Foreground = accentForeground;
+                            shortcutTile.TileButton.Background = tileTriggerBrush;
+                        }
                     }
                 }
 
@@ -645,7 +820,21 @@ namespace XboxGamingBar
                         bool enabled = legionTouchpadEnabled?.Value ?? false;
                         touchpadTile.StateText.Text = enabled ? "On" : "Off";
                         touchpadTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                        SetTileAccentBar(touchpadTile, enabled);
                         touchpadTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
+                    }
+                }
+
+                // Touchscreen tile
+                if (qsTileMap.TryGetValue("Touchscreen", out var touchscreenTile) && touchscreenTile.TileButton != null)
+                {
+                    if (legionGoDetected?.Value == true)
+                    {
+                        bool enabled = touchscreenEnabled?.Value ?? true;
+                        touchscreenTile.StateText.Text = enabled ? "On" : "Off";
+                        touchscreenTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                        SetTileAccentBar(touchscreenTile, enabled);
+                        touchscreenTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                     }
                 }
 
@@ -667,6 +856,7 @@ namespace XboxGamingBar
                         }
                         lightTile.StateText.Text = modeText;
                         lightTile.StateText.Foreground = mode > 0 ? accentForeground : offForeground;
+                        SetTileAccentBar(lightTile, mode > 0);
                         lightTile.TileButton.Background = mode > 0 ? tileOnBrush : tileOffBrush;
                     }
                 }
@@ -679,6 +869,7 @@ namespace XboxGamingBar
                         bool enabled = LegionDesktopControlsToggle?.IsOn ?? false;
                         desktopTile.StateText.Text = enabled ? "On" : "Off";
                         desktopTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                        SetTileAccentBar(desktopTile, enabled);
                         desktopTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                     }
                 }
@@ -695,6 +886,7 @@ namespace XboxGamingBar
                             profileName = profileName.Substring(0, 9) + "…";
                         remapTile.StateText.Text = profileName;
                         remapTile.StateText.Foreground = isGameProfile ? accentForeground : offForeground;
+                        SetTileAccentBar(remapTile, isGameProfile);
                         remapTile.TileButton.Background = isGameProfile ? tileOnBrush : tileOffBrush;
                     }
                 }
@@ -707,6 +899,7 @@ namespace XboxGamingBar
                         bool enabled = legionChargeLimit?.Value ?? false;
                         chargeLimitTile.StateText.Text = enabled ? "80%" : "Off";
                         chargeLimitTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                        SetTileAccentBar(chargeLimitTile, enabled);
                         chargeLimitTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                     }
                 }
@@ -719,6 +912,7 @@ namespace XboxGamingBar
                         bool enabled = legionPowerLight?.Value ?? false;
                         powerLightTile.StateText.Text = enabled ? "On" : "Off";
                         powerLightTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                        SetTileAccentBar(powerLightTile, enabled);
                         powerLightTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                     }
                 }
@@ -789,6 +983,7 @@ namespace XboxGamingBar
                         ceTile.StateText.Text = label;
                         ceTile.StateText.Foreground = enabled ? accentForeground : offForeground;
                     }
+                    SetTileAccentBar(ceTile, enabled);
                     ceTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                 }
 
@@ -806,6 +1001,7 @@ namespace XboxGamingBar
                     }
                     fanFullSpeedTile.StateText.Text = enabled ? "On" : "Off";
                     fanFullSpeedTile.StateText.Foreground = enabled ? accentForeground : offForeground;
+                    SetTileAccentBar(fanFullSpeedTile, enabled);
                     fanFullSpeedTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                 }
 
@@ -823,6 +1019,7 @@ namespace XboxGamingBar
                     }
                     vibrationTile.StateText.Text = levelText;
                     vibrationTile.StateText.Foreground = level > 0 ? accentForeground : offForeground;
+                    SetTileAccentBar(vibrationTile, level > 0);
                     vibrationTile.TileButton.Background = level > 0 ? tileOnBrush : tileOffBrush;
                 }
 
@@ -844,6 +1041,7 @@ namespace XboxGamingBar
                     }
                     vibrationModeTile.StateText.Text = vibModeText;
                     vibrationModeTile.StateText.Foreground = accentForeground;
+                    SetTileAccentBar(vibrationModeTile, true);
                     vibrationModeTile.TileButton.Background = tileOnBrush;
                 }
 
@@ -861,6 +1059,7 @@ namespace XboxGamingBar
                         screenSaverTile.StateText.Text = "Off";
                         screenSaverTile.StateText.Foreground = offForeground;
                     }
+                    SetTileAccentBar(screenSaverTile, enabled);
                     screenSaverTile.TileButton.Background = enabled ? tileOnBrush : tileOffBrush;
                 }
 
@@ -956,8 +1155,23 @@ namespace XboxGamingBar
                         bgBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 35, 55, 40)); // Green
 
                     batteryTile.StateText.Text = stateText;
-                    batteryTile.StateText.Foreground = accentForeground;
-                    batteryTile.TileButton.Background = bgBrush;
+                    if (win11)
+                    {
+                        // Win11: background stays neutral - our min-of-all-batteries
+                        // severity keeps its meaning but moves to the bottom bar and
+                        // subtitle color (the fork pinned this tile to green; we keep
+                        // our charge-level semantics and only move the presentation).
+                        SolidColorBrush batSeverity = minBat < 20 ? tileSeverityRedBrush
+                            : (minBat < 50 ? tileSeverityYellowBrush : tileSeverityGreenBrush);
+                        batteryTile.StateText.Foreground = batSeverity;
+                        if (batteryTile.AccentBar != null) batteryTile.AccentBar.Background = batSeverity;
+                        batteryTile.TileButton.Background = tileOffBrush;
+                    }
+                    else
+                    {
+                        batteryTile.StateText.Foreground = accentForeground;
+                        batteryTile.TileButton.Background = bgBrush;
+                    }
                 }
 
                 // Re-evaluate scrolling for every tile whose state text may have

--- a/XboxGamingBar/Features/QuickSettings/GamingWidget.QuickSettings.cs
+++ b/XboxGamingBar/Features/QuickSettings/GamingWidget.QuickSettings.cs
@@ -49,7 +49,35 @@ namespace XboxGamingBar
         private SolidColorBrush tileActiveBrush;
         private SolidColorBrush tileTriggerBrush;
         private LinearGradientBrush tileDefaultProfileBrush;
+
+        // ---- Win11 theme tile brushes (fork port, commit 77a24806) ----
+        // Active-tile accent signal: the live Windows accent color shows up on the
+        // state text ("On") and the bottom accent bar; tile background/icon/name
+        // stay neutral in Win11 mode.
+        private SolidColorBrush tileAccentBrush;
+        private SolidColorBrush tileBarOffBrush;
+        // Action/trigger tiles (Keyboard, custom shortcuts) use their own distinct
+        // color for the subtitle + bottom bar in Win11 mode, never the accent.
+        private SolidColorBrush tileActionBrush;
+        // Fixed severity colors for multi-state tiles (Battery, TDP Mode, Power
+        // Mode, EPP) - never tied to the live accent so the meaning (green=light/
+        // safe, blue=balanced, red=heavy/hot, purple=custom) stays consistent.
+        // Yellow is ours (not in the fork): the fork pinned Battery to green, but we
+        // keep our min-of-device+controller-batteries severity semantics and only
+        // move the presentation from background tint to bar.
+        private SolidColorBrush tileSeverityGreenBrush;
+        private SolidColorBrush tileSeverityBlueBrush;
+        private SolidColorBrush tileSeverityRedBrush;
+        private SolidColorBrush tileSeverityPurpleBrush;
+        private SolidColorBrush tileSeverityYellowBrush;
+
         private bool quickSettingsInitialized = false;
+
+        // Which style the tile/metrics UI was last BUILT for. The Win11 theme is a
+        // structural variant (accent bar vs background tint), so when the active
+        // theme's Win11-ness no longer matches this, ApplyTheme rebuilds the tiles
+        // and metrics grid. Set in RebuildQuickSettingsTiles.
+        private bool quickSettingsBuiltForWin11 = false;
 
         // Tile definitions with visibility tracking
         private class TileDefinition
@@ -66,6 +94,8 @@ namespace XboxGamingBar
             public Button TileButton { get; set; }
             public TextBlock StateText { get; set; }
             public CheckBox VisibilityCheckBox { get; set; }
+            public FontIcon IconElement { get; set; }     // Win11 theme: tile icon (Segoe Fluent Icons)
+            public Border AccentBar { get; set; }         // Win11 theme: bottom accent bar (null in classic builds)
 
             // For scrolling text animation (Profile tile)
             public Canvas StateTextCanvas { get; set; }
@@ -167,22 +197,8 @@ namespace XboxGamingBar
                 qsEditMode = false;
                 qsSelectedTileForMove = null;
 
-                // Dark mode colors with sharp contrast for handheld devices
-                // On state: use desaturated system accent color for subtle indication
-                var accentDark3 = (Windows.UI.Color)Application.Current.Resources["SystemAccentColorDark3"];
-                // Blend accent with dark gray to reduce saturation (40% accent, 60% dark base)
-                var darkBase = Windows.UI.Color.FromArgb(255, 26, 28, 30); // Same as tile off
-                var desaturatedAccent = Windows.UI.Color.FromArgb(
-                    255,
-                    (byte)((accentDark3.R * 0.4) + (darkBase.R * 0.6)),
-                    (byte)((accentDark3.G * 0.4) + (darkBase.G * 0.6)),
-                    (byte)((accentDark3.B * 0.4) + (darkBase.B * 0.6)));
-                tileOnBrush = new SolidColorBrush(desaturatedAccent);
-
-                // Other tile brushes - dark mode
-                tileOffBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 26, 28, 30));   // #1A1C1E
-                tileActiveBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 26, 37, 48)); // #1A2530 - dark blue
-                tileTriggerBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 37, 32, 48)); // #252030 - dark purple
+                // Tile brushes - consults the active theme (Win11 vs classic)
+                UpdateQuickSettingsThemeBrushes();
 
                 // Default Game Profile gradient brush (matches Performance tab card)
                 tileDefaultProfileBrush = new LinearGradientBrush
@@ -217,6 +233,61 @@ namespace XboxGamingBar
             {
                 Logger.Error($"Error initializing Quick Settings: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// (Re)computes the tile brushes for the active theme. Classic themes keep
+        /// the original dark palette (background tint = on/off signal); the Win11
+        /// theme (fork commit 77a24806) uses one flat neutral tile background and
+        /// signals state via the bottom accent bar instead. Called from
+        /// InitializeQuickSettings and again from ApplyTheme before a rebuild when
+        /// the theme's Win11-ness changed.
+        /// </summary>
+        private void UpdateQuickSettingsThemeBrushes()
+        {
+            if (IsWin11Theme)
+            {
+                // Flat neutral gray for every tile; on/off never tints the background.
+                tileOffBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 0x35, 0x39, 0x3F)); // #35393F
+                tileOnBrush = tileOffBrush;
+                // tileActive/tileTrigger keep their classic values (unused in the
+                // Win11 code paths, but non-null in case a stray path reads them).
+                tileActiveBrush = tileOffBrush;
+                tileTriggerBrush = tileOffBrush;
+            }
+            else
+            {
+                // Dark mode colors with sharp contrast for handheld devices
+                // On state: use desaturated system accent color for subtle indication
+                var accentDark3 = (Windows.UI.Color)Application.Current.Resources["SystemAccentColorDark3"];
+                // Blend accent with dark gray to reduce saturation (40% accent, 60% dark base)
+                var darkBase = Windows.UI.Color.FromArgb(255, 26, 28, 30); // Same as tile off
+                var desaturatedAccent = Windows.UI.Color.FromArgb(
+                    255,
+                    (byte)((accentDark3.R * 0.4) + (darkBase.R * 0.6)),
+                    (byte)((accentDark3.G * 0.4) + (darkBase.G * 0.6)),
+                    (byte)((accentDark3.B * 0.4) + (darkBase.B * 0.6)));
+                tileOnBrush = new SolidColorBrush(desaturatedAccent);
+
+                // Other tile brushes - dark mode
+                tileOffBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 26, 28, 30));   // #1A1C1E
+                tileActiveBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 26, 37, 48)); // #1A2530 - dark blue
+                tileTriggerBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 37, 32, 48)); // #252030 - dark purple
+            }
+
+            // Win11-mode accent/severity brushes (harmless to compute always).
+            tileAccentBrush = new SolidColorBrush((Windows.UI.Color)Application.Current.Resources["SystemAccentColorLight2"]);
+            // Same muted gray as the state text's "off" color, so the bar is always
+            // present (every tile) but reads as grayed-out when inactive.
+            tileBarOffBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 136, 136, 136));
+            // Light purple - distinct from the accent, used only by action/trigger tiles.
+            tileActionBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 180, 150, 200));
+            // Fixed severity colors - never tied to the live accent.
+            tileSeverityGreenBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 0x6C, 0xCB, 0x5F));  // Fluent "Success" green
+            tileSeverityBlueBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 0x4C, 0xC2, 0xFF));   // Windows blue swatch
+            tileSeverityRedBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 0xFF, 0x6B, 0x6B));    // App's established warning red
+            tileSeverityPurpleBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 0xB4, 0xA0, 0xFF)); // Distinct from tileActionBrush
+            tileSeverityYellowBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 0xFF, 0xD6, 0x66)); // Battery mid-charge (ours, not the fork's)
         }
 
         /// <summary>
@@ -281,6 +352,7 @@ namespace XboxGamingBar
             AddTileDefinition("ScreenSaver", "Idle Screen Off", "\uE7E8", order: order++);
             AddTileDefinition("Keyboard", "Keyboard", "\uE765", isTrigger: true, order: order++);
             AddTileDefinition("LegionTouchpad", "Touchpad", "\uE962", order: order++);
+            AddTileDefinition("Touchscreen", "Touchscreen", "\uE815", order: order++);
             AddTileDefinition("LegionRemapControls", "Remap", "\uE7FC", order: order++);
             AddTileDefinition("LegionDesktopControls", "Desktop", "\uE7F4", order: order++);
             // Quick toggle for the legacy controller emulation backend; state text shows

--- a/XboxGamingBar/GamingWidget.xaml
+++ b/XboxGamingBar/GamingWidget.xaml
@@ -5930,6 +5930,7 @@
                                             <ComboBoxItem Content="Dracula"/>
                                             <ComboBoxItem Content="Nord"/>
                                             <ComboBoxItem Content="Catppuccin"/>
+                                            <ComboBoxItem Content="Win11"/>
                                         </ComboBox>
                                     </Grid>
 
@@ -6937,9 +6938,9 @@
                             <StackPanel>
                                 <TextBlock x:Name="LegionDeviceNameText" Text="Legion Go Controller" Style="{StaticResource CardTitleStyle}"/>
                                 <TextBlock x:Name="LegionControllerStatusText"
-                                           Text="Connected"
+                                           Text="Not detected"
                                            FontSize="14"
-                                           Foreground="#4CAF50"
+                                           Foreground="#888888"
                                            Margin="0,4,0,0"/>
 
                                 <!-- Controller Battery Info (hidden on devices without detachable controllers) -->

--- a/XboxGamingBar/GamingWidget.xaml
+++ b/XboxGamingBar/GamingWidget.xaml
@@ -5361,6 +5361,28 @@
                                                    Margin="0,6,0,0"
                                                    Visibility="Collapsed"/>
 
+                                        <!-- Front buttons (Desktop / Page) -> emulated controller button -->
+                                        <TextBlock Text="Desktop button" FontSize="12" Foreground="#CCCCCC" Margin="0,12,0,4"/>
+                                        <ComboBox x:Name="ViiperDesktopButtonTargetComboBox" HorizontalAlignment="Stretch">
+                                            <ComboBoxItem Content="None" Tag="none"/>
+                                            <ComboBoxItem Content="Guide / PS" Tag="guide"/>
+                                            <ComboBoxItem Content="Touchpad click (Sony/Deck)" Tag="touchpad"/>
+                                            <ComboBoxItem Content="Share / Create / View" Tag="share"/>
+                                            <ComboBoxItem Content="Options / Start / Menu" Tag="options"/>
+                                            <ComboBoxItem Content="L3 (left stick click)" Tag="l3"/>
+                                            <ComboBoxItem Content="R3 (right stick click)" Tag="r3"/>
+                                        </ComboBox>
+                                        <TextBlock Text="Page button" FontSize="12" Foreground="#CCCCCC" Margin="0,12,0,4"/>
+                                        <ComboBox x:Name="ViiperPageButtonTargetComboBox" HorizontalAlignment="Stretch">
+                                            <ComboBoxItem Content="None" Tag="none"/>
+                                            <ComboBoxItem Content="Guide / PS" Tag="guide"/>
+                                            <ComboBoxItem Content="Touchpad click (Sony/Deck)" Tag="touchpad"/>
+                                            <ComboBoxItem Content="Share / Create / View" Tag="share"/>
+                                            <ComboBoxItem Content="Options / Start / Menu" Tag="options"/>
+                                            <ComboBoxItem Content="L3 (left stick click)" Tag="l3"/>
+                                            <ComboBoxItem Content="R3 (right stick click)" Tag="r3"/>
+                                        </ComboBox>
+
                                         <!-- Swap rumble motors -->
                                         <Grid Margin="0,12,0,0">
                                             <Grid.ColumnDefinitions>

--- a/XboxGamingBar/GamingWidget.xaml.cs
+++ b/XboxGamingBar/GamingWidget.xaml.cs
@@ -634,10 +634,39 @@ namespace XboxGamingBar
                 ButtonBorder = Windows.UI.Color.FromArgb(255, 88, 91, 112),       // #585B70
                 TileOff = Windows.UI.Color.FromArgb(255, 24, 24, 37),             // #181825
                 TileOn = Windows.UI.Color.FromArgb(255, 166, 227, 161)            // #A6E3A1 (green)
+            }},
+            // Win11 - ported from the Rayekkk/GoTweaks-Lite fork (commits f04f1e78 +
+            // 77a24806 + e1cb6ef9): flat neutral cards/tiles (#35393F) with a
+            // translucent white hairline border, accent signalled by a bottom bar on
+            // tiles instead of a background tint. AccentColor below is a static
+            // fallback (Windows blue swatch) - at apply time GetThemeAccentBrush
+            // substitutes the live SystemAccentColorLight2.
+            { "Win11", new ThemeColors {
+                Name = "Win11",
+                PageBackground = Windows.UI.Color.FromArgb(255, 37, 40, 44),      // #25282C (fork kept default)
+                CardBackground = Windows.UI.Color.FromArgb(255, 0x35, 0x39, 0x3F),// #35393F flat neutral
+                CardBorder = Windows.UI.Color.FromArgb(0x22, 255, 255, 255),      // #22FFFFFF translucent hairline
+                AccentColor = Windows.UI.Color.FromArgb(255, 0x4C, 0xC2, 0xFF),   // #4CC2FF (fallback; live accent used at runtime)
+                TextPrimary = Windows.UI.Color.FromArgb(255, 255, 255, 255),      // #FFFFFF
+                TextSecondary = Windows.UI.Color.FromArgb(255, 160, 160, 160),    // #A0A0A0
+                ButtonBackground = Windows.UI.Color.FromArgb(255, 62, 67, 75),    // #3E434B (fork kept default)
+                ButtonBorder = Windows.UI.Color.FromArgb(0x22, 255, 255, 255),    // #22FFFFFF
+                TileOff = Windows.UI.Color.FromArgb(255, 0x35, 0x39, 0x3F),       // #35393F flat neutral
+                TileOn = Windows.UI.Color.FromArgb(255, 0x35, 0x39, 0x3F)         // same - "on" is signalled by the accent bar
             }}
         };
 
         private string currentThemeName = "Default";
+
+        /// <summary>
+        /// True when the Win11 theme is active. The Win11 theme is a structural
+        /// variant, not just a palette: Quick Settings tiles signal on/off via a
+        /// bottom accent bar instead of a background tint, the metrics grid uses
+        /// an icon-over-value-over-label layout with dividers, and cards get
+        /// CornerRadius 10 / BorderThickness 1. Consulted by CreateTileButton,
+        /// UpdateQuickSettingsTileStates, RebuildMetricsGrid and the theme walker.
+        /// </summary>
+        private bool IsWin11Theme => currentThemeName == "Win11";
 
         // Xbox Game Bar logic
         private XboxGameBarWidget widget = null;
@@ -715,6 +744,7 @@ namespace XboxGamingBar
         private readonly CurrentTDPProperty currentTdp;
         private readonly RunningGameProperty runningGame;
         private readonly PerGameProfileProperty perGameProfile;
+        private readonly DeleteGameProfileProperty deleteGameProfile;
         private readonly CPUBoostProperty cpuBoost;
         private readonly CPUEPPProperty cpuEPP;
         private readonly MaxCPUStateProperty maxCPUState;
@@ -730,6 +760,7 @@ namespace XboxGamingBar
         private readonly DisplayOrientationProperty displayOrientation;
         private readonly HDRSupportedProperty hdrSupported;
         private readonly HDREnabledProperty hdrEnabled;
+        private readonly TouchscreenEnabledProperty touchscreenEnabled;
         private readonly AdaptiveBrightnessModeProperty adaptiveBrightnessMode;
         private readonly WidgetSliderProperty panelBrightness;
         private readonly PanelBrightnessSupportedProperty panelBrightnessSupported;
@@ -1403,6 +1434,7 @@ namespace XboxGamingBar
                 UpdateDetectedGameScrollAnimation();
             });
             perGameProfile = new PerGameProfileProperty(PerGameProfileToggle, this);
+            deleteGameProfile = new DeleteGameProfileProperty();
             cpuBoost = new CPUBoostProperty(CPUBoostToggle, this);
             cpuEPP = new CPUEPPProperty(80, CPUEPPSlider, this);
             maxCPUState = new MaxCPUStateProperty();
@@ -1420,6 +1452,7 @@ namespace XboxGamingBar
             displayOrientation = new DisplayOrientationProperty();
             hdrSupported = new HDRSupportedProperty(HDRToggle, this);
             hdrEnabled = new HDREnabledProperty(HDRToggle, this);
+            touchscreenEnabled = new TouchscreenEnabledProperty();
             adaptiveBrightnessMode = new AdaptiveBrightnessModeProperty(AdaptiveBrightnessModeComboBox, this);
             // Slider ValueChanged (PanelBrightnessSlider_ValueChanged) updates the % label on
             // both user drags and helper-pushed sync (the base sets UI.Value), so no extra hook.
@@ -1837,6 +1870,7 @@ namespace XboxGamingBar
                 tdp,
                 runningGame,
                 perGameProfile,
+                deleteGameProfile,
                 cpuBoost,
                 cpuEPP,
                 maxCPUState,
@@ -1852,6 +1886,7 @@ namespace XboxGamingBar
                 displayOrientation,
                 hdrSupported,
                 hdrEnabled,
+                touchscreenEnabled,
                 adaptiveBrightnessMode,
                 panelBrightness,
                 panelBrightnessSupported,
@@ -2481,10 +2516,48 @@ namespace XboxGamingBar
                 }
                 RightControllerChargingIcon.Visibility = rightCharging ? Visibility.Visible : Visibility.Collapsed;
                 RightControllerConnectionText.Text = rightConnected ? "Attached" : "Detached";
+
+                UpdateLegionControllerOverallStatus(leftConnected, rightConnected, leftBattery, rightBattery);
             }
             catch (Exception ex)
             {
                 Logger.Error($"Error updating Legion controller battery display: {ex.Message}");
+            }
+        }
+
+        // #4CAF50 matches the "good" green used by GetBatteryBrush and the battery text.
+        private static readonly Windows.UI.Xaml.Media.SolidColorBrush _legionControllerStatusGreen =
+            new Windows.UI.Xaml.Media.SolidColorBrush(Windows.UI.Color.FromArgb(255, 0x4C, 0xAF, 0x50));
+        private static readonly Windows.UI.Xaml.Media.SolidColorBrush _legionControllerStatusGray =
+            new Windows.UI.Xaml.Media.SolidColorBrush(Windows.UI.Color.FromArgb(255, 0x88, 0x88, 0x88));
+
+        /// <summary>
+        /// Drives the top-of-card status line: "Attached" when at least one controller is
+        /// physically docked, "Connected" when detached-but-paired (wireless) controllers are
+        /// still reporting data, "Not detected" when neither controller has any signal yet.
+        /// </summary>
+        private void UpdateLegionControllerOverallStatus(bool leftConnected, bool rightConnected, int leftBattery, int rightBattery)
+        {
+            if (LegionControllerStatusText == null) return;
+
+            bool anyAttached = leftConnected || rightConnected;
+            bool anyPresent = anyAttached || leftBattery >= 0 || rightBattery >= 0
+                               || !string.IsNullOrEmpty(controllerVidPid?.Value);
+
+            if (anyAttached)
+            {
+                LegionControllerStatusText.Text = "Attached";
+                LegionControllerStatusText.Foreground = _legionControllerStatusGreen;
+            }
+            else if (anyPresent)
+            {
+                LegionControllerStatusText.Text = "Connected";
+                LegionControllerStatusText.Foreground = _legionControllerStatusGreen;
+            }
+            else
+            {
+                LegionControllerStatusText.Text = "Not detected";
+                LegionControllerStatusText.Foreground = _legionControllerStatusGray;
             }
         }
 
@@ -2520,11 +2593,33 @@ namespace XboxGamingBar
                 {
                     LegionControllerPidVidText.Text = "VID:PID --";
                 }
+                UpdateLegionControllerInfoSectionVisibility();
+
+                // VID:PID can arrive before battery/connected data does — re-evaluate the
+                // top status line so it doesn't sit on "Not detected" longer than necessary.
+                UpdateLegionControllerOverallStatus(
+                    controllerConnectedLeft?.Value ?? false,
+                    controllerConnectedRight?.Value ?? false,
+                    controllerBatteryLeft?.Value ?? -1,
+                    controllerBatteryRight?.Value ?? -1);
             }
             catch (Exception ex)
             {
                 Logger.Error($"Error updating Legion controller VID:PID display: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Shows the Controller Information table as soon as EITHER VID:PID or the
+        /// device-status JSON has data, instead of gating solely on device-status —
+        /// the two properties can arrive independently and out of order.
+        /// </summary>
+        private void UpdateLegionControllerInfoSectionVisibility()
+        {
+            if (LegionControllerInfoSection == null) return;
+            bool hasVidPid = !string.IsNullOrEmpty(controllerVidPid?.Value);
+            bool hasDeviceStatus = !string.IsNullOrEmpty(controllerDeviceStatus?.Value);
+            LegionControllerInfoSection.Visibility = (hasVidPid || hasDeviceStatus) ? Visibility.Visible : Visibility.Collapsed;
         }
 
         private void LegionControllerDeviceStatus_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -2565,10 +2660,9 @@ namespace XboxGamingBar
             {
                 Logger.Info("UpdateLegionControllerDeviceStatusDisplay: ENTER");
                 string json = controllerDeviceStatus?.Value ?? "";
+                UpdateLegionControllerInfoSectionVisibility();
                 if (string.IsNullOrEmpty(json))
                 {
-                    if (LegionControllerInfoSection != null)
-                        LegionControllerInfoSection.Visibility = Visibility.Collapsed;
                     return;
                 }
 
@@ -2598,8 +2692,6 @@ namespace XboxGamingBar
 
                 Logger.Info($"UpdateLegionControllerDeviceStatusDisplay: parsed fw={fw} le={lightEnabled} lm={lightMode} br={brightness} sp={speed} vb={vibration} tp={touchpad}");
 
-                if (LegionControllerInfoSection != null)
-                    LegionControllerInfoSection.Visibility = Visibility.Visible;
                 if (LegionControllerFirmwareText != null)
                     LegionControllerFirmwareText.Text = string.IsNullOrEmpty(fw) ? "—" : fw;
 
@@ -3269,6 +3361,22 @@ namespace XboxGamingBar
             Logger.Info("Registering this GamingWidget instance as the active widget.");
             App.RegisterActiveGamingWidget(this);
             Logger.Info("GamingWidget instance registered as active.");
+
+            // Re-bind this instance's pipe handlers unconditionally, even if the pipe is
+            // already connected. Game Bar can recreate the GamingWidget Page in place
+            // (display-mode/dock changes) without ever dropping the named pipe. When that
+            // happens the code below takes the "already connected" branch and never calls
+            // TryConnectPipeAsync — which is the ONLY other place these handlers get
+            // (re)subscribed. Without this, the new active instance never receives live
+            // pipe pushes (e.g. Function.QuickMetrics), so anything driven purely by push
+            // (like the Quick Metrics row) freezes at its last value / "--" until the
+            // widget is fully closed and reopened, forcing a real reconnect. -= before +=
+            // keeps this idempotent for the fresh-connect path, where TryConnectPipeAsync
+            // does the same subscription right after.
+            App.PipeMessageReceived -= PipeClient_MessageReceived;
+            App.PipeMessageReceived += PipeClient_MessageReceived;
+            App.PipeDisconnected -= PipeClient_Disconnected;
+            App.PipeDisconnected += PipeClient_Disconnected;
 
             //while (!System.Diagnostics.Debugger.IsAttached)
             //{

--- a/XboxGamingBar/GamingWidget.xaml.cs
+++ b/XboxGamingBar/GamingWidget.xaml.cs
@@ -983,6 +983,8 @@ namespace XboxGamingBar
         private readonly ViiperStringComboProperty viiperSonySubDevice;
         private readonly ViiperStringComboProperty viiperNintendoSubDevice;
         private readonly ViiperStringComboProperty viiperGuideButtonMode;
+        private readonly ViiperStringComboProperty viiperDesktopButtonTarget;
+        private readonly ViiperStringComboProperty viiperPageButtonTarget;
         private readonly ViiperSwapRumbleMotorsProperty viiperSwapRumbleMotors;
         private readonly ViiperMirrorLightbarToStickProperty viiperMirrorLightbarToStick;
         private readonly ViiperStickGyroEnabledProperty viiperStickGyroEnabled;
@@ -1704,6 +1706,8 @@ namespace XboxGamingBar
             viiperSonySubDevice = new ViiperStringComboProperty("dualsense-edge", Shared.Enums.Function.Viiper_SonySubDevice, ViiperSonySubDeviceComboBox, this);
             viiperNintendoSubDevice = new ViiperStringComboProperty("switchpro", Shared.Enums.Function.Viiper_NintendoSubDevice, ViiperNintendoSubDeviceComboBox, this);
             viiperGuideButtonMode = new ViiperStringComboProperty("Native", Shared.Enums.Function.Viiper_GuideButtonMode, ViiperGuideButtonModeComboBox, this);
+            viiperDesktopButtonTarget = new ViiperStringComboProperty("guide", Shared.Enums.Function.Viiper_DesktopButtonTarget, ViiperDesktopButtonTargetComboBox, this);
+            viiperPageButtonTarget = new ViiperStringComboProperty("touchpad", Shared.Enums.Function.Viiper_PageButtonTarget, ViiperPageButtonTargetComboBox, this);
             viiperSwapRumbleMotors = new ViiperSwapRumbleMotorsProperty(ViiperSwapRumbleMotorsToggle, this);
             viiperMirrorLightbarToStick = new ViiperMirrorLightbarToStickProperty(ViiperMirrorLightbarToStickToggle, this);
             viiperStickGyroEnabled = new ViiperStickGyroEnabledProperty(ViiperStickGyroEnabledToggle, this);
@@ -1978,6 +1982,8 @@ namespace XboxGamingBar
                 viiperSonySubDevice,
                 viiperNintendoSubDevice,
                 viiperGuideButtonMode,
+                viiperDesktopButtonTarget,
+                viiperPageButtonTarget,
                 viiperSwapRumbleMotors,
                 viiperRumbleIntensity,
                 viiperMirrorLightbarToStick,

--- a/XboxGamingBar/XboxGamingBar.csproj
+++ b/XboxGamingBar/XboxGamingBar.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Data\AMD\AMDImageSharpeningSharpnessProperty.cs" />
     <Compile Include="Data\AMD\AMDDisplayColorProperties.cs" />
     <Compile Include="Data\AutoStartRTSSProperty.cs" />
+    <Compile Include="Data\Profile\DeleteGameProfileProperty.cs" />
     <Compile Include="Data\Profile\ProfileMatchByExeProperty.cs" />
     <Compile Include="Data\Profile\ProfileGamesOnlyProperty.cs" />
     <Compile Include="Data\Profile\ProfileCustomGamePathProperty.cs" />
@@ -276,6 +277,7 @@
     <Compile Include="Data\AdaptiveBrightnessModeProperty.cs" />
     <Compile Include="Data\RTSSInstalledProperty.cs" />
     <Compile Include="Data\PanelBrightnessSupportedProperty.cs" />
+    <Compile Include="Data\TouchscreenEnabledProperty.cs" />
     <Compile Include="Data\FPSLimitProperty.cs" />
     <Compile Include="Data\OSPowerModeProperty.cs" />
     <Compile Include="Data\RunningGameProperty.cs" />

--- a/XboxGamingBarHelper/ControllerEmulation/Viiper/UsbipCli.cs
+++ b/XboxGamingBarHelper/ControllerEmulation/Viiper/UsbipCli.cs
@@ -1,0 +1,203 @@
+using NLog;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace XboxGamingBarHelper.ControllerEmulation.Viiper
+{
+    /// <summary>
+    /// Thin wrapper over usbip-win2's usbip.exe, used to explicitly attach libviiper's
+    /// exported devices to the local UDE bus (and detach them on teardown).
+    ///
+    /// WHY THIS EXISTS: libviiper's viiper_device_add is *documented* to auto-attach the
+    /// device to the local UDE driver, but on some usbip-win2 UDE installs that internal
+    /// attach silently no-ops — viiper_device_add returns success and the USBIP server
+    /// exports the device on 127.0.0.1:3241, yet no child ever appears under the UDE host
+    /// controller and "usbip.exe port" stays empty, so no gamepad reaches Windows.
+    /// Driving the standard usbip client against libviiper's own loopback server lands it.
+    ///
+    /// Verified on-device 2026-07-08 (LeGo2, usbip-win2 0.9.7.8): the internal auto-attach
+    /// produced nothing (empty UDE host-controller child list, empty "usbip.exe port"), but
+    ///   usbip.exe -t 3241 attach -r 127.0.0.1 -b 1-1
+    /// plugged in the emulated DualSense and gamepads worked. This class reproduces that
+    /// call after every device add. It is idempotent (devices already attached are skipped),
+    /// so on machines where the internal auto-attach *does* work it is a harmless no-op
+    /// rather than a duplicate attachment.
+    /// </summary>
+    internal static class UsbipCli
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        // Must match ViiperService.Initialize's listen address.
+        private const string Host = "127.0.0.1";
+        private const int Port = 3241;
+
+        private static readonly string[] ExePaths =
+        {
+            @"C:\Program Files\USBip\usbip.exe",
+            @"C:\Program Files (x86)\USBip\usbip.exe",
+        };
+
+        private static string ResolveExe()
+        {
+            foreach (var p in ExePaths)
+            {
+                if (File.Exists(p)) return p;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Attaches every device libviiper is exporting on its loopback USBIP server that
+        /// isn't already imported into the local UDE bus. Best-effort: logs and returns
+        /// quietly if usbip.exe is missing or the CLI misbehaves.
+        /// </summary>
+        public static void AttachExportedDevices()
+        {
+            string exe = ResolveExe();
+            if (exe == null)
+            {
+                Logger.Warn("usbip.exe not found; cannot attach VIIPER device to the UDE bus.");
+                return;
+            }
+
+            // The server registers the device synchronously inside viiper_device_add, but
+            // allow a couple of short retries in case the export list lags right after add.
+            for (int attempt = 0; attempt < 3; attempt++)
+            {
+                var exported = ListExportedBusIds(exe);
+                if (exported.Count == 0)
+                {
+                    System.Threading.Thread.Sleep(200);
+                    continue;
+                }
+
+                var attached = ListAttachedBusIds(exe);
+                int attachedNow = 0;
+                foreach (var busId in exported)
+                {
+                    if (attached.Contains(busId))
+                    {
+                        Logger.Debug($"usbip: {busId} already attached, skipping.");
+                        continue;
+                    }
+                    if (Attach(exe, busId)) attachedNow++;
+                }
+                Logger.Info($"usbip: exported={exported.Count}, newly attached={attachedNow}.");
+                return;
+            }
+            Logger.Warn("usbip: libviiper exported no devices after add (attach skipped).");
+        }
+
+        /// <summary>Detaches every UDE port imported from libviiper's loopback server. Best-effort.</summary>
+        public static void DetachAll()
+        {
+            string exe = ResolveExe();
+            if (exe == null) return;
+
+            string output = Run(exe, $"-t {Port} port");
+            if (string.IsNullOrEmpty(output)) return;
+
+            // Walk "Port NN:" blocks, collect the numbers of blocks referencing our loopback
+            // server so we never detach an unrelated usbip import the user set up themselves.
+            var ports = new List<string>();
+            string currentPort = null;
+            bool currentIsOurs = false;
+            foreach (var raw in output.Split('\n'))
+            {
+                var pm = Regex.Match(raw, @"Port\s+(\d+)\s*:");
+                if (pm.Success)
+                {
+                    if (currentPort != null && currentIsOurs) ports.Add(currentPort);
+                    currentPort = pm.Groups[1].Value;
+                    currentIsOurs = false;
+                }
+                if (raw.IndexOf(Host, StringComparison.OrdinalIgnoreCase) >= 0) currentIsOurs = true;
+            }
+            if (currentPort != null && currentIsOurs) ports.Add(currentPort);
+
+            foreach (var p in ports)
+            {
+                string o = Run(exe, $"detach -p {p}");
+                Logger.Info($"usbip detach -p {p} -> {(o ?? string.Empty).Trim()}");
+            }
+        }
+
+        private static List<string> ListExportedBusIds(string exe)
+        {
+            var result = new List<string>();
+            string output = Run(exe, $"-t {Port} list -r {Host}");
+            if (string.IsNullOrEmpty(output)) return result;
+            // Exported lines look like: "    1-1    : Sony Corp. : DualSense ... (054c:0df2)"
+            foreach (var line in output.Split('\n'))
+            {
+                var m = Regex.Match(line, @"^\s*(\d+-\d+)\s*:");
+                if (m.Success) result.Add(m.Groups[1].Value);
+            }
+            return result;
+        }
+
+        private static HashSet<string> ListAttachedBusIds(string exe)
+        {
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            string output = Run(exe, $"-t {Port} port");
+            if (string.IsNullOrEmpty(output)) return set;
+            // usbip-win2 port output references the remote busid, e.g.
+            //   "1-1 -> usbip://127.0.0.1:3241/1-1"
+            // Only trust busids on lines that mention our loopback server, so an unrelated
+            // usbip import is never mistaken for one of ours (which would skip a real attach).
+            foreach (var line in output.Split('\n'))
+            {
+                if (line.IndexOf(Host, StringComparison.OrdinalIgnoreCase) < 0) continue;
+                var m = Regex.Match(line, @"(\d+-\d+)");
+                if (m.Success) set.Add(m.Groups[1].Value);
+            }
+            return set;
+        }
+
+        private static bool Attach(string exe, string busId)
+        {
+            string output = Run(exe, $"-t {Port} attach -r {Host} -b {busId}");
+            // usbip attach prints nothing meaningful on success; an "error" line signals failure.
+            bool failed = output != null && output.IndexOf("error", StringComparison.OrdinalIgnoreCase) >= 0;
+            if (failed)
+            {
+                Logger.Warn($"usbip attach -b {busId} failed: {output.Trim()}");
+                return false;
+            }
+            Logger.Info($"usbip attach -b {busId} succeeded.");
+            return true;
+        }
+
+        private static string Run(string exe, string args)
+        {
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = exe,
+                    Arguments = args,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                };
+                using (var proc = Process.Start(psi))
+                {
+                    if (proc == null) return string.Empty;
+                    string stdout = proc.StandardOutput.ReadToEnd();
+                    string stderr = proc.StandardError.ReadToEnd();
+                    proc.WaitForExit(15000);
+                    return (stdout ?? string.Empty) + "\n" + (stderr ?? string.Empty);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug($"usbip exec failed ({args}): {ex.Message}");
+                return string.Empty;
+            }
+        }
+    }
+}

--- a/XboxGamingBarHelper/ControllerEmulation/Viiper/ViiperEmulationManager.cs
+++ b/XboxGamingBarHelper/ControllerEmulation/Viiper/ViiperEmulationManager.cs
@@ -531,6 +531,11 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
             }
             guideOnlyPhysicalXInputSlot = -1;
 
+            // Detach our UDE imports first (we attach explicitly via usbip.exe on add — see
+            // UsbipCli), then tear down the server side.
+            try { UsbipCli.DetachAll(); }
+            catch (Exception ex) { Logger.Warn($"VIIPER guide-only usbip detach threw: {ex.Message}"); }
+
             try
             {
                 if (activeDeviceId != 0)
@@ -1074,6 +1079,11 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
                 catch (Exception ex) { Logger.Warn($"VIIPER HidHide Disable threw: {ex.Message}"); }
                 viiperOwnsSuppression = false;
             }
+
+            // Detach our UDE imports first (we attach explicitly via usbip.exe on add — see
+            // UsbipCli), then tear down the server side.
+            try { UsbipCli.DetachAll(); }
+            catch (Exception ex) { Logger.Warn($"usbip detach threw: {ex.Message}"); }
 
             try
             {

--- a/XboxGamingBarHelper/ControllerEmulation/Viiper/ViiperEmulationManager.cs
+++ b/XboxGamingBarHelper/ControllerEmulation/Viiper/ViiperEmulationManager.cs
@@ -117,6 +117,14 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
                 {
                     settingsManager.ViiperGuideButtonMode.PropertyChanged += OnGuideModeChanged;
                 }
+                if (settingsManager.ViiperDesktopButtonTarget != null)
+                {
+                    settingsManager.ViiperDesktopButtonTarget.PropertyChanged += OnFrontButtonTargetChanged;
+                }
+                if (settingsManager.ViiperPageButtonTarget != null)
+                {
+                    settingsManager.ViiperPageButtonTarget.PropertyChanged += OnFrontButtonTargetChanged;
+                }
                 if (settingsManager.ViiperSwapRumbleMotors != null)
                 {
                     settingsManager.ViiperSwapRumbleMotors.PropertyChanged += OnSwapRumbleMotorsChanged;
@@ -670,6 +678,9 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
             forwarder.SetGyroSource(ResolveGyroSource());
             forwarder.SetJoyconGyroPerHalf(settingsManager?.ViiperJoyconGyroPerHalf?.Value ?? false);
             forwarder.SetGuideButtonMode(ResolveGuideMode());
+            forwarder.SetFrontButtonTargets(
+                settingsManager?.ViiperDesktopButtonTarget?.Value ?? "guide",
+                settingsManager?.ViiperPageButtonTarget?.Value ?? "touchpad");
             forwarder.SetSwapRumbleMotors(settingsManager?.ViiperSwapRumbleMotors?.Value ?? false);
             forwarder.SetRumbleIntensity(settingsManager?.ViiperRumbleIntensity?.Value ?? 100);
             forwarder.SetMirrorLightbarToStick(settingsManager?.ViiperMirrorLightbarToStick?.Value ?? false);
@@ -845,6 +856,17 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
             catch (Exception ex) { Logger.Warn($"OnGuideModeChanged threw: {ex.Message}"); }
         }
 
+        private void OnFrontButtonTargetChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            try
+            {
+                forwarder.SetFrontButtonTargets(
+                    settingsManager?.ViiperDesktopButtonTarget?.Value ?? "guide",
+                    settingsManager?.ViiperPageButtonTarget?.Value ?? "touchpad");
+            }
+            catch (Exception ex) { Logger.Warn($"OnFrontButtonTargetChanged threw: {ex.Message}"); }
+        }
+
         private void OnSwapRumbleMotorsChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             try { forwarder.SetSwapRumbleMotors(settingsManager?.ViiperSwapRumbleMotors?.Value ?? false); }
@@ -892,9 +914,34 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
             catch (Exception ex) { Logger.Warn($"OnGyroAxisMapChanged threw: {ex.Message}"); }
         }
 
+        private System.Threading.Timer _deviceConfigDebounceTimer;
+        private readonly object _deviceSwapLock = new object();
+        private const int DeviceConfigDebounceMs = 500;
+
         private void OnDeviceConfigChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             if (!isRunning) return; // Will be picked up on next Start().
+
+            // Debounce rapid config changes (e.g. spinning the Sony sub-device dropdown) into a
+            // single hot-swap once the selection settles. Without this, every intermediate value
+            // fired a full RemoveDevice+AddDevice, churning virtual devices faster than the async
+            // ghost-PnP cleanup could evict them — leaving phantom duplicate gamepads (all fed by
+            // the one forwarder, hence identical input).
+            var t = _deviceConfigDebounceTimer;
+            if (t == null)
+                _deviceConfigDebounceTimer = new System.Threading.Timer(
+                    _ => PerformDeviceConfigSwap(), null, DeviceConfigDebounceMs, System.Threading.Timeout.Infinite);
+            else
+                t.Change(DeviceConfigDebounceMs, System.Threading.Timeout.Infinite);
+        }
+
+        private void PerformDeviceConfigSwap()
+        {
+            lock (_deviceSwapLock)
+            {
+            try
+            {
+            if (!isRunning) return;
 
             string oldType = activeDeviceType;
             string newType;
@@ -997,6 +1044,9 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
             {
                 forwarder.SetPaused(false);
             }
+            }
+            catch (Exception ex) { Logger.Error(ex, "PerformDeviceConfigSwap threw"); }
+            } // _deviceSwapLock
         }
 
         public void Stop()

--- a/XboxGamingBarHelper/ControllerEmulation/Viiper/ViiperInputForwarder.cs
+++ b/XboxGamingBarHelper/ControllerEmulation/Viiper/ViiperInputForwarder.cs
@@ -23,6 +23,22 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
         GameBar = 1,
     }
 
+    /// <summary>
+    /// Logical emulated-controller button a Legion front button (Desktop/Page) maps to. Resolved
+    /// per emulated type in the wire builders; the type-agnostic ones ride the XInput button field
+    /// so every builder translates them, and Touchpad is Sony/Deck-only.
+    /// </summary>
+    internal enum FrontButtonTarget
+    {
+        None = 0,
+        Guide,        // PS / Xbox Guide / Steam button
+        Touchpad,     // Sony touchpad click / Deck touchpad (no-op on Xbox)
+        ShareView,    // Share/Create (Sony) / View/Back (Xbox)
+        OptionsMenu,  // Options (Sony) / Menu/Start (Xbox)
+        L3,
+        R3,
+    }
+
     /// <summary>Which IMU source (if any) feeds the gyro bytes of the VIIPER wire format.</summary>
     internal enum ViiperGyroSourceKind
     {
@@ -182,6 +198,15 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
         [System.Runtime.InteropServices.DllImport("winmm.dll", EntryPoint = "timeEndPeriod")]
         private static extern uint NativeTimeEndPeriod(uint uMilliseconds);
         private volatile ViiperGuideButtonMode guideMode = ViiperGuideButtonMode.Native;
+
+        // Configurable emulated-button target for the Legion Desktop (Mode) / Page (Share) front
+        // buttons. Standard targets are injected into the XInput button field so every wire
+        // builder translates them correctly; Touchpad is Sony/Deck-only and applied via the
+        // per-frame _auxTouchpadClick flag. Defaults match the prior hardcoded behavior.
+        private volatile FrontButtonTarget _desktopFrontTarget = FrontButtonTarget.Guide;
+        private volatile FrontButtonTarget _pageFrontTarget = FrontButtonTarget.Touchpad;
+        private bool _auxTouchpadClick;
+
         private volatile bool swapRumbleMotors;
         // Percent ×10 so we can apply it with integer math (1000 == unity). Range 0..2000.
         private volatile int rumbleIntensityScaled = 1000;
@@ -984,6 +1009,69 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
             Logger.Info($"VIIPER forwarder guide-button mode -> {mode}");
         }
 
+        /// <summary>Set the emulated-button target for the Legion Desktop (Mode) / Page (Share) front buttons.</summary>
+        public void SetFrontButtonTargets(string desktop, string page)
+        {
+            _desktopFrontTarget = ParseFrontTarget(desktop, FrontButtonTarget.Guide);
+            _pageFrontTarget = ParseFrontTarget(page, FrontButtonTarget.Touchpad);
+            Logger.Info($"VIIPER forwarder front-button targets -> Desktop={_desktopFrontTarget}, Page={_pageFrontTarget}");
+        }
+
+        private static FrontButtonTarget ParseFrontTarget(string s, FrontButtonTarget fallback)
+        {
+            switch ((s ?? "").Trim().ToLowerInvariant())
+            {
+                case "none":     return FrontButtonTarget.None;
+                case "guide":    return FrontButtonTarget.Guide;
+                case "touchpad": return FrontButtonTarget.Touchpad;
+                case "share":    return FrontButtonTarget.ShareView;
+                case "options":  return FrontButtonTarget.OptionsMenu;
+                case "l3":       return FrontButtonTarget.L3;
+                case "r3":       return FrontButtonTarget.R3;
+                default:         return fallback;
+            }
+        }
+
+        /// <summary>
+        /// Map the Legion Desktop (Mode) / Page (Share) front buttons to their configured emulated
+        /// buttons before the wire builder runs. Standard targets are OR-ed into the XInput button
+        /// field (every builder translates them); Touchpad sets a per-frame flag the Sony/Deck
+        /// builders read. The Mode/Share aux bits are then cleared so the builders' legacy hardcoded
+        /// mappings don't double-fire. Guide is handled by the caller's guide-mode logic when the
+        /// Desktop target is Guide, so this only injects Guide in Native mode (Mode still set).
+        /// </summary>
+        private void ApplyConfigurableAuxButtons(ref ViiperXInputGamepad gp)
+        {
+            _auxTouchpadClick = false;
+
+            if ((currentAuxButtons & LegionAux.Mode) != 0)
+            {
+                ApplyFrontTargetToGamepad(_desktopFrontTarget, ref gp);
+                currentAuxButtons &= unchecked((ushort)~LegionAux.Mode);
+            }
+            if ((currentAuxButtons & LegionAux.Share) != 0)
+            {
+                ApplyFrontTargetToGamepad(_pageFrontTarget, ref gp);
+                currentAuxButtons &= unchecked((ushort)~LegionAux.Share);
+            }
+        }
+
+        private void ApplyFrontTargetToGamepad(FrontButtonTarget target, ref ViiperXInputGamepad gp)
+        {
+            switch (target)
+            {
+                case FrontButtonTarget.Guide:       gp.Buttons |= ViiperXInput.Guide; break;
+                case FrontButtonTarget.ShareView:   gp.Buttons |= ViiperXInput.Back; break;
+                case FrontButtonTarget.OptionsMenu: gp.Buttons |= ViiperXInput.Start; break;
+                case FrontButtonTarget.L3:          gp.Buttons |= ViiperXInput.LeftThumb; break;
+                case FrontButtonTarget.R3:          gp.Buttons |= ViiperXInput.RightThumb; break;
+                case FrontButtonTarget.Touchpad:    _auxTouchpadClick = true; break;
+                case FrontButtonTarget.None:
+                default:
+                    break;
+            }
+        }
+
         public void SetSwapRumbleMotors(bool swap)
         {
             if (swapRumbleMotors == swap) return;
@@ -1587,10 +1675,14 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
                         // Guide-button mode: if the user wants Mode/Guide to open Xbox Game
                         // Bar instead of the emulated PS/Guide button, fire Win+G on press
                         // edge and strip the press from the outgoing state.
+                        // The Desktop (Mode) front button only acts as Guide when it's mapped to
+                        // Guide; in that case honor the guide-button mode (native emulated guide
+                        // vs Win+G). Otherwise ApplyConfigurableAuxButtons maps Mode to its target.
+                        bool desktopIsGuide = _desktopFrontTarget == FrontButtonTarget.Guide;
                         bool guidePressed = ((sample.Buttons & ViiperXInput.Guide) != 0)
-                                         || ((currentAuxButtons & LegionAux.Mode) != 0);
+                                         || (desktopIsGuide && (currentAuxButtons & LegionAux.Mode) != 0);
                         ApplyGuideModeEdge(guidePressed);
-                        if (guideMode == ViiperGuideButtonMode.GameBar)
+                        if (desktopIsGuide && guideMode == ViiperGuideButtonMode.GameBar)
                         {
                             currentAuxButtons &= unchecked((ushort)~LegionAux.Mode);
                         }
@@ -1650,6 +1742,7 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
                                 }
                             }
                         }
+                        ApplyConfigurableAuxButtons(ref gp);
                         ApplyStickTriggerShaping(ref gp);
                         byte[] data = BuildDeviceInput(gp);
                         if (data != null && data.Length > 0)
@@ -1727,6 +1820,7 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
                                 }
                             }
                         }
+                        ApplyConfigurableAuxButtons(ref gp);
                         ApplyStickTriggerShaping(ref gp);
                         byte[] data = BuildDeviceInput(gp);
                         if (data != null && data.Length > 0)
@@ -2249,7 +2343,7 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
             // user gets from Legion HID, so they don't go to waste in the DS4 mapping).
             ushort aux = currentAuxButtons;
             if ((aux & LegionAux.Mode) != 0) ds4Buttons |= 0x0001;   // Mode -> PS
-            if ((aux & LegionAux.Share) != 0) ds4Buttons |= 0x0002;  // Share -> Touchpad click
+            if (_auxTouchpadClick) ds4Buttons |= 0x0002;  // configured front button -> Touchpad click
             WriteU16(data, 4, ds4Buttons);
 
             byte dpad = 0;
@@ -2331,7 +2425,7 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
             if ((aux & LegionAux.Y3) != 0) dseButtons |= 0x00200000;    // Y3 (right upper) -> ExtraR1
             if ((aux & LegionAux.M3) != 0) dseButtons |= 0x00800000;    // M3 (right lower) -> ExtraL3
             if ((aux & LegionAux.Mode) != 0) dseButtons |= 0x00010000;  // Mode  -> PS
-            if ((aux & LegionAux.Share) != 0) dseButtons |= 0x00020000; // Share -> Touchpad click
+            if (_auxTouchpadClick) dseButtons |= 0x00020000; // configured front button -> Touchpad click
             WriteU32(data, 4, dseButtons);
 
             byte dpad = 0;
@@ -2534,7 +2628,7 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
 
             ushort aux = currentAuxButtons;
             if ((aux & LegionAux.Mode) != 0) dsButtons |= 0x00010000;             // Mode  → PS
-            if ((aux & LegionAux.Share) != 0) dsButtons |= 0x00020000;            // Share → Touchpad click
+            if (_auxTouchpadClick) dsButtons |= 0x00020000;            // configured front button → Touchpad click
             WriteU32(data, 4, dsButtons);
 
             byte dpad = 0;
@@ -2647,8 +2741,8 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
             if ((gp.Buttons & ViiperXInput.DPadRight) != 0) dpad |= 0x08;
             data[12] = dpad;
 
-            // Share → reserved bit at byte 13 (matches reference app's mapping).
-            if ((aux & LegionAux.Share) != 0) data[13] |= 0x01;
+            // Configured front button → Touchpad/reserved bit at byte 13 (reference app mapping).
+            if (_auxTouchpadClick) data[13] |= 0x01;
 
             // Bytes 14-25: IMU (gyro X/Y/Z + accel X/Y/Z as int16). libviiper's
             // xboxelite2 InputState already carries these on the wire for Steam

--- a/XboxGamingBarHelper/ControllerEmulation/Viiper/ViiperService.cs
+++ b/XboxGamingBarHelper/ControllerEmulation/Viiper/ViiperService.cs
@@ -136,13 +136,15 @@ namespace XboxGamingBarHelper.ControllerEmulation.Viiper
             }
             Logger.Info($"VIIPER device added: {typeName} (bus={busId}, dev={deviceId}, vid=0x{vid:X4}, pid=0x{pid:X4})");
 
-            // NOTE: do NOT call viiper_device_attach here. libviiper's viiper_device_add[_ex]
-            // already attaches the device internally — calling attach a second time produces
-            // a *duplicate* USBIP attachment, surfacing two emulated controllers to Windows
-            // (caught during local test of build 2067 with steam-generic mode). Diagnostic
-            // visibility for "did Windows actually see the device?" comes from the existing
-            // ViiperInputForwarder 5s stats line: reportsSent > 0 + user reports no input
-            // means attach worked but downstream consumption didn't.
+            // libviiper's viiper_device_add is *supposed* to auto-attach the device to the
+            // local UDE bus, but on some usbip-win2 UDE installs that internal attach silently
+            // no-ops: add returns success and the device is exported on 127.0.0.1:3241, yet no
+            // child ever appears under the UDE host controller and no gamepad reaches Windows
+            // (verified on-device 2026-07-08, LeGo2 + usbip-win2 0.9.7.8). Drive the standard
+            // usbip client explicitly to land it. UsbipCli is idempotent — a device already
+            // attached (e.g. the internal auto-attach DID fire) is skipped, so this never
+            // produces the duplicate USBIP attachment the old auto-attach-only path warned of.
+            UsbipCli.AttachExportedDevices();
 
             RegisterFeedbackCallback(busId, deviceId);
             return new ViiperAddDeviceResult(true, deviceId);

--- a/XboxGamingBarHelper/Devices/Libraries/Legion/LegionManager.cs
+++ b/XboxGamingBarHelper/Devices/Libraries/Legion/LegionManager.cs
@@ -2316,7 +2316,7 @@ namespace XboxGamingBarHelper.Devices.Libraries.Legion
                 period: EC_FAN_TICK_MS);
         }
 
-        private void StopEcFanCurveLoop()
+        internal void StopEcFanCurveLoop()
         {
             if (ecFanCurveTimer == null) return;
             ecFanCurveTimer.Dispose();

--- a/XboxGamingBarHelper/Labs/LegionButtonMonitor.cs
+++ b/XboxGamingBarHelper/Labs/LegionButtonMonitor.cs
@@ -2507,6 +2507,14 @@ namespace XboxGamingBarHelper.Labs
             int reconnectDelayMs = 1000;
             const int MAX_RECONNECT_DELAY_MS = 10000;
             const uint READ_TIMEOUT_MS = 100; // Short timeout so we can check isRunning frequently
+            // Consecutive read TIMEOUTS (handle still valid but no reports arriving). A timeout
+            // is NOT a read error, so the failure-based reconnect below never fires on it — the
+            // monitor could sit dead for ~100s when a HidHide cycle-port (fired by controller
+            // emulation to hide the physical pad) re-enumerates the Legion USB composite and
+            // stales our MI_02 handle. After ~2s of silence force a reconnect so the LegionHid
+            // input source + battery/status polling recover in a couple seconds instead.
+            int consecutiveReadTimeouts = 0;
+            const int READ_TIMEOUTS_BEFORE_RECONNECT = 20; // 20 x 100ms = ~2s of no reports
 
             // Controller heartbeat - send init command every 3 seconds to keep controller in initialized mode
             // Legion Space uses 5 second timeout, so 3 seconds gives us margin
@@ -2609,8 +2617,29 @@ namespace XboxGamingBarHelper.Labs
 
                             if (waitResult == WAIT_TIMEOUT)
                             {
-                                // Timeout - cancel and check if we should continue
+                                // Timeout - cancel the pending read.
                                 CancelIo(hidHandle);
+
+                                // Prolonged read starvation: the handle still looks valid but
+                                // the device has stopped delivering reports (typically after a
+                                // HidHide cycle-port re-enumerated the Legion USB composite during
+                                // controller emulation, staling this MI_02 handle). A timeout is
+                                // not a read error, so the failure-based reconnect never fires and
+                                // the monitor sits dead until the device happens to resume (~100s
+                                // observed). After ~2s of silence, drop the handle so the loop top
+                                // reconnects (reopens the current device instance + re-inits it).
+                                if (++consecutiveReadTimeouts >= READ_TIMEOUTS_BEFORE_RECONNECT)
+                                {
+                                    Logger.Warn($"LegionButtonMonitor: no HID reports for ~{consecutiveReadTimeouts * READ_TIMEOUT_MS / 1000.0:0.#}s (handle likely staled by a HidHide cycle-port) — forcing reconnect");
+                                    if (hidHandle != null && !hidHandle.IsInvalid)
+                                    {
+                                        hidHandle.Close();
+                                    }
+                                    hidHandle = null;
+                                    _hasWriteAccess = false;
+                                    _highQualityGyroConfigured = false;
+                                    consecutiveReadTimeouts = 0;
+                                }
                                 continue;
                             }
                             else if (waitResult == WAIT_OBJECT_0)
@@ -2658,6 +2687,7 @@ namespace XboxGamingBarHelper.Labs
                         if (readResult && bytesRead >= 1)
                         {
                             consecutiveFailures = 0; // Reset on successful read
+                            consecutiveReadTimeouts = 0; // reports flowing again — clear the starvation counter
 
                             // Diagnostic: measure actual HID report arrival rate.
                             // Counts every successful ReadFile completion and emits

--- a/XboxGamingBarHelper/LosslessScaling/LosslessScalingManager.cs
+++ b/XboxGamingBarHelper/LosslessScaling/LosslessScalingManager.cs
@@ -33,6 +33,11 @@ namespace XboxGamingBarHelper.LosslessScaling
 
         private const string PROCESS_NAME = "LosslessScaling";
         private const int STEAM_APP_ID = 993090;
+
+        // Minimum length for a profile's window-title filter to be eligible for the
+        // loose substring matching strategies. Without this a filter like "a"/"go"
+        // would match almost any game and select the wrong profile.
+        private const int MIN_FILTER_MATCH_LENGTH = 3;
         private static readonly string SETTINGS_PATH = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "Lossless Scaling",
@@ -157,9 +162,26 @@ namespace XboxGamingBarHelper.LosslessScaling
 
         // State tracking
         private bool isScalingActive = false;
-        private int isRunningPollCount = 0;
         private bool isRunningLastResult = false;
-        private bool isRunningLogged = false;
+
+        // Guards the throttle/cache/current-game fields below, which are touched from
+        // both the manager Update() timer thread and pipe/profile threads (SetCurrentGame,
+        // property-change handlers). Kept for short synchronous sections only — never
+        // held across an await.
+        private readonly object stateLock = new object();
+
+        // IsRunning() result cache. The poll enumerates processes on every Update()
+        // tick and is also read by several action paths; a short TTL de-dupes those
+        // reads. Paths that just launched or killed LS call IsRunning() directly so the
+        // fresh result is observed at once (and the cache refreshed).
+        private bool cachedIsRunning = false;
+        private DateTime lastRunningCheck = DateTime.MinValue;
+        private static readonly TimeSpan RunningCacheTtl = TimeSpan.FromMilliseconds(1000);
+
+        // Installation re-detection throttle (so the Scale tab can appear/disappear
+        // at runtime without a helper restart when LS is installed/uninstalled).
+        private DateTime lastInstalledCheck = DateTime.MinValue;
+        private static readonly TimeSpan InstalledRecheckInterval = TimeSpan.FromSeconds(10);
 
         public LosslessScalingManager() : base()
         {
@@ -230,10 +252,40 @@ namespace XboxGamingBarHelper.LosslessScaling
         {
             base.Update();
 
-            bool currentlyRunning = IsRunning();
+            bool currentlyRunning = IsRunningCached();
             if (losslessScalingRunning.Value != currentlyRunning)
             {
                 losslessScalingRunning.SetValue(currentlyRunning, DateTime.Now.Ticks);
+
+                // LS exited → no scaling can be active. Reset the best-effort tracker so
+                // the next enable starts from a known state. (Toggles made via LS's own
+                // hotkey while it runs cannot be observed — that stays a blind spot.)
+                if (!currentlyRunning)
+                {
+                    lock (stateLock) { isScalingActive = false; }
+                }
+            }
+
+            // Periodically re-detect installation so the Scale tab (and Quick Settings
+            // tile) appear/disappear without a helper restart when the user installs,
+            // uninstalls, or first-launches LS while GoTweaks is already running.
+            bool doInstalledCheck;
+            lock (stateLock)
+            {
+                doInstalledCheck = DateTime.UtcNow - lastInstalledCheck >= InstalledRecheckInterval;
+                if (doInstalledCheck)
+                {
+                    lastInstalledCheck = DateTime.UtcNow;
+                }
+            }
+            if (doInstalledCheck)
+            {
+                bool currentlyInstalled = IsInstalled();
+                if (losslessScalingInstalled.Value != currentlyInstalled)
+                {
+                    Logger.Info($"Lossless Scaling installation state changed → {currentlyInstalled}");
+                    losslessScalingInstalled.SetValue(currentlyInstalled, DateTime.Now.Ticks);
+                }
             }
         }
 
@@ -242,10 +294,15 @@ namespace XboxGamingBarHelper.LosslessScaling
         /// </summary>
         public void SetCurrentGame(string gameName, string exePath)
         {
-            if (currentGameExePath == exePath)
-                return;
+            // Compound check-then-act on the shared field: guard so two threads
+            // (Update timer vs. profile/pipe) can't both pass the dedup for the same game.
+            lock (stateLock)
+            {
+                if (currentGameExePath == exePath)
+                    return;
+                currentGameExePath = exePath;
+            }
 
-            currentGameExePath = exePath;
             Logger.Info($"Current game changed to: {gameName} ({exePath})");
 
             // Find profile for this game - try multiple matching strategies
@@ -255,7 +312,7 @@ namespace XboxGamingBarHelper.LosslessScaling
                 profileName = "Default";
             }
 
-            currentProfileName = profileName;
+            lock (stateLock) { currentProfileName = profileName; }
             losslessScalingCurrentProfile.SetValue(profileName, DateTime.Now.Ticks);
 
             // Load settings from the profile
@@ -269,23 +326,39 @@ namespace XboxGamingBarHelper.LosslessScaling
 
         private bool IsInstalled()
         {
-            // Check both settings file and exe exist
-            // Settings file alone isn't enough - user may have uninstalled but settings remain
-            if (!File.Exists(SETTINGS_PATH))
-            {
-                return false;
-            }
-
+            // Presence of the LosslessScaling.exe (located via the Steam library) is
+            // the source of truth. Settings.xml is created only on the FIRST LS launch,
+            // so requiring it here would hide the Scale tab for a freshly-installed but
+            // never-run LS. When Settings.xml is missing we simply fall back to the
+            // built-in LosslessScalingSettings defaults.
             string exePath = FindLosslessScalingExePath();
             return !string.IsNullOrEmpty(exePath) && File.Exists(exePath);
         }
 
+        /// <summary>
+        /// Cached view of <see cref="IsRunning"/> for high-frequency callers. Returns the
+        /// last result within <see cref="RunningCacheTtl"/>, otherwise re-polls. Paths that
+        /// just launched or killed LS call <see cref="IsRunning"/> directly so the fresh
+        /// result is observed at once (and the cache refreshed).
+        /// </summary>
+        private bool IsRunningCached()
+        {
+            lock (stateLock)
+            {
+                if (DateTime.UtcNow - lastRunningCheck < RunningCacheTtl)
+                {
+                    return cachedIsRunning;
+                }
+            }
+            return IsRunning();
+        }
+
         private bool IsRunning()
         {
-            // vvalente30 issue #79: helper kept reporting Running=False for 10 min
-            // while LS was actually running. Either LS exe name varies between
-            // installs, or GetProcessesByName silently throws on his machine.
-            // Log the first few polls + every state transition to find out which.
+            // Only log on a state transition (or a genuine failure) to keep the helper
+            // log clean — this is polled frequently.
+            // (vvalente30 issue #79: LS process name can be absent or the enumeration
+            // can throw on some machines — the Warn below surfaces that case.)
             int procCount = -1;
             string error = null;
             try
@@ -304,33 +377,36 @@ namespace XboxGamingBarHelper.LosslessScaling
 
             bool isRunning = procCount > 0;
 
-            bool stateChanged = isRunning != isRunningLastResult;
-            bool logFirstFew = isRunningPollCount < 5;
-            if (stateChanged || logFirstFew || error != null || !isRunningLogged)
+            lock (stateLock)
             {
                 if (error != null)
                 {
-                    Logger.Warn($"Lossless Scaling IsRunning() poll #{isRunningPollCount} threw — {error}");
+                    Logger.Warn($"Lossless Scaling IsRunning() poll threw — {error}");
                 }
-                else
+                else if (isRunning != isRunningLastResult)
                 {
-                    Logger.Info($"Lossless Scaling IsRunning() poll #{isRunningPollCount}: name='{PROCESS_NAME}' procs={procCount} → {isRunning}{(stateChanged ? " (state changed)" : "")}");
+                    Logger.Info($"Lossless Scaling running state changed → {isRunning} (procs={procCount})");
                 }
-                isRunningLogged = true;
+
+                isRunningLastResult = isRunning;
+                cachedIsRunning = isRunning;
+                lastRunningCheck = DateTime.UtcNow;
             }
 
-            isRunningPollCount++;
-            isRunningLastResult = isRunning;
             return isRunning;
         }
 
         public async Task<bool> LaunchLosslessScalingAsync()
         {
-            if (IsRunning())
+            if (IsRunningCached())
             {
                 Logger.Info("Lossless Scaling is already running.");
                 return true;
             }
+
+            // A freshly launched LS always starts with scaling OFF, so reset the
+            // best-effort tracker here. The enable handler then toggles it on if needed.
+            lock (stateLock) { isScalingActive = false; }
 
             try
             {
@@ -418,17 +494,17 @@ namespace XboxGamingBarHelper.LosslessScaling
 
                 if (string.IsNullOrEmpty(steamPath))
                 {
-                    Logger.Warn("Could not find Steam installation path in registry");
+                    Logger.Debug("Could not find Steam installation path in registry");
                     return null;
                 }
 
-                Logger.Info($"Found Steam path: {steamPath}");
+                Logger.Debug($"Found Steam path: {steamPath}");
 
                 // Check default steamapps location first
                 string defaultLibrary = Path.Combine(steamPath, "steamapps", "common", "Lossless Scaling", "LosslessScaling.exe");
                 if (File.Exists(defaultLibrary))
                 {
-                    Logger.Info($"Found Lossless Scaling at default location: {defaultLibrary}");
+                    Logger.Debug($"Found Lossless Scaling at default location: {defaultLibrary}");
                     return defaultLibrary;
                 }
 
@@ -446,13 +522,13 @@ namespace XboxGamingBarHelper.LosslessScaling
 
                         if (File.Exists(lsPath))
                         {
-                            Logger.Info($"Found Lossless Scaling in library: {lsPath}");
+                            Logger.Debug($"Found Lossless Scaling in library: {lsPath}");
                             return lsPath;
                         }
                     }
                 }
 
-                Logger.Warn("Could not find Lossless Scaling executable in any Steam library");
+                Logger.Debug("Could not find Lossless Scaling executable in any Steam library");
                 return null;
             }
             catch (Exception ex)
@@ -517,7 +593,7 @@ namespace XboxGamingBarHelper.LosslessScaling
 
         private void ToggleScaling()
         {
-            if (!IsRunning())
+            if (!IsRunningCached())
             {
                 Logger.Warn("Cannot toggle scaling: Lossless Scaling is not running");
                 return;
@@ -533,8 +609,13 @@ namespace XboxGamingBarHelper.LosslessScaling
             {
                 Logger.Info($"Sending {currentHotkeyDescription} hotkey to toggle Lossless Scaling...");
                 inputInjector.InjectKeyboardInput(toggleScalingKeyboardCombo);
-                isScalingActive = !isScalingActive;
-                Logger.Info($"Scaling toggled to: {isScalingActive}");
+                bool nowActive;
+                lock (stateLock)
+                {
+                    isScalingActive = !isScalingActive;
+                    nowActive = isScalingActive;
+                }
+                Logger.Info($"Scaling toggled to: {nowActive}");
             }
             catch (Exception ex)
             {
@@ -785,7 +866,7 @@ namespace XboxGamingBarHelper.LosslessScaling
                     foreach (var profile in profiles)
                     {
                         var pathFilter = profile.Element("Path")?.Value;
-                        if (string.IsNullOrEmpty(pathFilter))
+                        if (string.IsNullOrEmpty(pathFilter) || pathFilter.Length < MIN_FILTER_MATCH_LENGTH)
                             continue;
 
                         // Check if game name contains the path filter (Lossless Scaling style matching)
@@ -808,12 +889,12 @@ namespace XboxGamingBarHelper.LosslessScaling
                 if (!string.IsNullOrEmpty(exePath))
                 {
                     string exeName = System.IO.Path.GetFileNameWithoutExtension(exePath);
-                    if (!string.IsNullOrEmpty(exeName))
+                    if (!string.IsNullOrEmpty(exeName) && exeName.Length >= MIN_FILTER_MATCH_LENGTH)
                     {
                         foreach (var profile in profiles)
                         {
                             var pathFilter = profile.Element("Path")?.Value;
-                            if (string.IsNullOrEmpty(pathFilter))
+                            if (string.IsNullOrEmpty(pathFilter) || pathFilter.Length < MIN_FILTER_MATCH_LENGTH)
                                 continue;
 
                             if (exeName.IndexOf(pathFilter, StringComparison.OrdinalIgnoreCase) >= 0 ||
@@ -1023,7 +1104,7 @@ namespace XboxGamingBarHelper.LosslessScaling
                 Logger.Info($"Created profile '{gameName}' for '{exePath}'");
 
                 // Update current profile
-                currentProfileName = gameName;
+                lock (stateLock) { currentProfileName = gameName; }
                 losslessScalingCurrentProfile.SetValue(gameName, DateTime.Now.Ticks);
             }
             catch (Exception ex)
@@ -1103,7 +1184,9 @@ namespace XboxGamingBarHelper.LosslessScaling
                     }
                 }
 
-                if (isScalingActive != shouldBeEnabled)
+                bool active;
+                lock (stateLock) { active = isScalingActive; }
+                if (active != shouldBeEnabled)
                 {
                     ToggleScaling();
                 }
@@ -1124,7 +1207,9 @@ namespace XboxGamingBarHelper.LosslessScaling
                 Logger.Info("Save and Restart triggered");
 
                 // Write settings to the current profile
-                WriteSettingsToProfile(currentProfileName);
+                string profileToWrite;
+                lock (stateLock) { profileToWrite = currentProfileName; }
+                WriteSettingsToProfile(profileToWrite);
 
                 // Kill Lossless Scaling if running
                 if (IsRunning())

--- a/XboxGamingBarHelper/Performance/PerformanceManager.cs
+++ b/XboxGamingBarHelper/Performance/PerformanceManager.cs
@@ -130,6 +130,12 @@ namespace XboxGamingBarHelper.Performance
         public HardwareSensor GPUWattage { get; private set; }
         public GPUTemperatureSensor GPUTemperature { get; }
 
+        // The sensor object that always queries GPU-hardware power sensors, regardless of
+        // which public property (CPUWattage/GPUWattage) currently exposes it after the
+        // device-specific swap in the constructor. Used by the ADLX GPU fallback — see the
+        // swap comment for why the GPUWattage property alone isn't a safe target.
+        private HardwareSensor gpuHardwareWattageSensor;
+
         public MemoryUsageSensor MemoryUsage { get; }
         public MemoryUsedSensor MemoryUsed { get; }
         public MemoryAvailableSensor MemoryAvailable { get; }
@@ -639,6 +645,14 @@ namespace XboxGamingBarHelper.Performance
             GPUClock = new GPUClockSensor();
             GPUTemperature = new GPUTemperatureSensor();
             GPUWattage = new GPUWattageSensor();
+
+            // Remember the sensor object that actually queries GPU hardware ("GPU Core" /
+            // "GPU Package" / "GPU Power") BEFORE the LeGo2 swap below can reassign the
+            // GPUWattage property to something else. FillGpuSensorsFromAdlxFallback needs this
+            // fixed reference — it fills in ADLX data specifically when the GPU-hardware LHM
+            // sensor is absent (a known LeGo2/Z2 gap), and must keep targeting that same
+            // sensor object regardless of which public property currently exposes it.
+            gpuHardwareWattageSensor = GPUWattage;
 
             // LeGo2 (Ryzen Z2 Extreme): LibreHardwareMonitor's CPU "Package" sensor
             // reports what AMD Adrenalin's overlay labels GPU Power, and the GPU
@@ -1208,7 +1222,7 @@ namespace XboxGamingBarHelper.Performance
             bool needAny =
                 IsMissing(pendingValues, GPUUsage) ||
                 IsMissing(pendingValues, GPUClock) ||
-                IsMissing(pendingValues, GPUWattage) ||
+                IsMissing(pendingValues, gpuHardwareWattageSensor) ||
                 IsMissing(pendingValues, GPUTemperature) ||
                 IsMissing(pendingValues, GPUMemoryClock);
             if (!needAny)
@@ -1233,9 +1247,9 @@ namespace XboxGamingBarHelper.Performance
                 pendingValues[GPUClock] = snap.GpuClockMHz;
                 filled++;
             }
-            if (IsMissing(pendingValues, GPUWattage) && snap.HasPowerW)
+            if (IsMissing(pendingValues, gpuHardwareWattageSensor) && snap.HasPowerW)
             {
-                pendingValues[GPUWattage] = (float)snap.GpuPowerW;
+                pendingValues[gpuHardwareWattageSensor] = (float)snap.GpuPowerW;
                 filled++;
             }
             if (IsMissing(pendingValues, GPUTemperature) && snap.HasTemperatureC)
@@ -1429,7 +1443,7 @@ namespace XboxGamingBarHelper.Performance
                                     // actually enforces — let the verification read fill
                                     // Current* so the OSD/widget report the truth instead
                                     // of echoing the requested values.
-                                    ScheduleVerificationRead();
+                                    ScheduleLegionPawnIOVerificationRead();
                                     return;
                                 }
                                 // No independent read-back path on non-Legion hardware —
@@ -1496,6 +1510,50 @@ namespace XboxGamingBarHelper.Performance
                 catch (Exception ex)
                 {
                     Logger.Debug($"ScheduleVerificationRead: Error during verification read: {ex.Message}");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Delayed Legion-WMI read used specifically after a PawnIO/RyzenSMU write on Legion
+        /// hardware, where the Lenovo EC silently re-asserts its own power table over the SMU
+        /// write within seconds. Deliberately does NOT go through UpdateCurrentTDP — that method
+        /// only reads Legion WMI when TdpMethod==ManufacturerWMI (its "Priority 1" gate), so
+        /// calling it here (TdpMethod==PawnIO) would hit the dead WinRing0-removed fallback and
+        /// silently do nothing, leaving the OSD stuck on the last value instead of showing what
+        /// the EC actually enforces.
+        /// </summary>
+        private void ScheduleLegionPawnIOVerificationRead()
+        {
+            System.Threading.Tasks.Task.Run(async () =>
+            {
+                try
+                {
+                    await System.Threading.Tasks.Task.Delay(VerificationDelayMs);
+                    if (legionManager == null) return;
+
+                    var (slow, fast, peak) = legionManager.GetCurrentTDPValues();
+                    if (!slow.HasValue || !fast.HasValue || !peak.HasValue)
+                    {
+                        Logger.Debug("ScheduleLegionPawnIOVerificationRead: Could not read all TDP values from Legion WMI");
+                        return;
+                    }
+
+                    CurrentSPL = slow.Value;
+                    CurrentSPPT = fast.Value;
+                    CurrentFPPT = peak.Value;
+
+                    var newTdpString = $"SPL:{slow}W SPPT:{fast}W FPPT:{peak}W";
+                    if (newTdpString != lastTdpString)
+                    {
+                        Logger.Info($"ScheduleLegionPawnIOVerificationRead: EC-enforced TDP is '{newTdpString}' (PawnIO write may not have stuck)");
+                        currentTdp.SetValue(newTdpString);
+                        lastTdpString = newTdpString;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Debug($"ScheduleLegionPawnIOVerificationRead: Error during verification read: {ex.Message}");
                 }
             });
         }

--- a/XboxGamingBarHelper/Power/PowerManager.cs
+++ b/XboxGamingBarHelper/Power/PowerManager.cs
@@ -294,6 +294,18 @@ namespace XboxGamingBarHelper.Power
         /// </summary>
         public static void SetMaxCPUState(bool isAC, uint percentage)
         {
+            // Save original values before first modification (for clean uninstall)
+            try
+            {
+                uint currentAC = GetMaxCPUState(true);
+                uint currentDC = GetMaxCPUState(false);
+                SystemRestoreService.SaveOriginalMaxCpuState(currentAC, currentDC);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"Failed to save original Max CPU State values: {ex.Message}");
+            }
+
             Guid scheme = GetActiveScheme();
             Guid subgroup = PowerGuids.GUID_PROCESSOR_SETTINGS_SUBGROUP;
             Guid setting = PowerGuids.GUID_PROCESSOR_THROTTLE_MAX;
@@ -357,6 +369,18 @@ namespace XboxGamingBarHelper.Power
         /// </summary>
         public static void SetMinCPUState(bool isAC, uint percentage)
         {
+            // Save original values before first modification (for clean uninstall)
+            try
+            {
+                uint currentAC = GetMinCPUState(true);
+                uint currentDC = GetMinCPUState(false);
+                SystemRestoreService.SaveOriginalMinCpuState(currentAC, currentDC);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"Failed to save original Min CPU State values: {ex.Message}");
+            }
+
             Guid scheme = GetActiveScheme();
             Guid subgroup = PowerGuids.GUID_PROCESSOR_SETTINGS_SUBGROUP;
             Guid setting = PowerGuids.GUID_PROCESSOR_THROTTLE_MIN;
@@ -439,6 +463,20 @@ namespace XboxGamingBarHelper.Power
         /// <returns>True if successful</returns>
         public static bool SetOSPowerMode(int mode)
         {
+            // Save original value before first modification (for clean uninstall)
+            try
+            {
+                int currentMode = GetOSPowerMode();
+                if (currentMode >= 0)
+                {
+                    SystemRestoreService.SaveOriginalOsPowerMode(currentMode);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"Failed to save original OS Power Mode value: {ex.Message}");
+            }
+
             try
             {
                 Guid targetGuid;

--- a/XboxGamingBarHelper/Profile/DeleteGameProfileProperty.cs
+++ b/XboxGamingBarHelper/Profile/DeleteGameProfileProperty.cs
@@ -35,6 +35,11 @@ namespace XboxGamingBarHelper.Profile
                 {
                     Logger.Warn($"Failed to delete profile for: {Value} (not found)");
                 }
+
+                // Reset the trigger to empty (silently, no echo) so deleting the SAME game
+                // name again later in this helper session isn't dropped by the equal-value
+                // dedupe in GenericProperty.SetValue.
+                SetValueSilent("");
             }
         }
     }

--- a/XboxGamingBarHelper/Program.cs
+++ b/XboxGamingBarHelper/Program.cs
@@ -1487,6 +1487,8 @@ namespace XboxGamingBarHelper
                 settingsManager.ViiperSonySubDevice,
                 settingsManager.ViiperNintendoSubDevice,
                 settingsManager.ViiperGuideButtonMode,
+                settingsManager.ViiperDesktopButtonTarget,
+                settingsManager.ViiperPageButtonTarget,
                 settingsManager.ViiperSwapRumbleMotors,
                 settingsManager.ViiperRumbleIntensity,
                 settingsManager.GoTweaksLightingConfig,

--- a/XboxGamingBarHelper/Program.cs
+++ b/XboxGamingBarHelper/Program.cs
@@ -374,10 +374,12 @@ namespace XboxGamingBarHelper
             {
                 try
                 {
-                    Logger.Warn("ProcessExit fired — releasing EC fan + HidHide suppression before shutdown");
+                    Logger.Warn("ProcessExit fired — releasing EC fan + HidHide suppression + VIIPER bus before shutdown");
                     legionManager?.EmergencyReleaseFanOverride();
                     try { controllerEmulationManager?.SuppressionManager?.Disable(); }
                     catch (Exception ex) { Logger.Warn($"ProcessExit HidHide.Disable threw: {ex.Message}"); }
+                    try { viiperEmulationManager?.Dispose(); }
+                    catch (Exception ex) { Logger.Warn($"ProcessExit VIIPER.Dispose threw: {ex.Message}"); }
                     LogManager.Flush();
                 }
                 catch { }
@@ -386,10 +388,12 @@ namespace XboxGamingBarHelper
             {
                 try
                 {
-                    Logger.Error($"UnhandledException — releasing EC fan + HidHide suppression. Exception: {e.ExceptionObject}");
+                    Logger.Error($"UnhandledException — releasing EC fan + HidHide suppression + VIIPER bus. Exception: {e.ExceptionObject}");
                     legionManager?.EmergencyReleaseFanOverride();
                     try { controllerEmulationManager?.SuppressionManager?.Disable(); }
                     catch (Exception ex) { Logger.Warn($"UnhandledException HidHide.Disable threw: {ex.Message}"); }
+                    try { viiperEmulationManager?.Dispose(); }
+                    catch (Exception ex) { Logger.Warn($"UnhandledException VIIPER.Dispose threw: {ex.Message}"); }
                     LogManager.Flush();
                 }
                 catch { }
@@ -1414,6 +1418,7 @@ namespace XboxGamingBarHelper
                 systemManager.AdaptiveBrightnessMode,
                 systemManager.PanelBrightness,
                 systemManager.PanelBrightnessSupported,
+                systemManager.TouchscreenEnabled,
                 systemManager.CPUCoreConfig,
                 systemManager.CPUCoreActiveConfig,
                 systemManager.CoreParkingPercent,

--- a/XboxGamingBarHelper/RTSS/RTSSFPSLimiter.cs
+++ b/XboxGamingBarHelper/RTSS/RTSSFPSLimiter.cs
@@ -51,8 +51,12 @@ namespace XboxGamingBarHelper.RTSS
         /// </summary>
         public static bool Initialize()
         {
-            if (_isInitialized)
-                return _isAvailable;
+            // Only short-circuit once we've SUCCEEDED. A prior failed attempt
+            // (RTSS not installed / DLL missing at helper start) must be able to
+            // re-attempt later — callers gate this on the RTSS not-running→running
+            // transition, so re-attempts are rare, not per-tick.
+            if (_isInitialized && _isAvailable)
+                return true;
 
             _isInitialized = true;
 

--- a/XboxGamingBarHelper/RTSS/RTSSManager.cs
+++ b/XboxGamingBarHelper/RTSS/RTSSManager.cs
@@ -60,6 +60,12 @@ namespace XboxGamingBarHelper.RTSS
 
         private RivatunerStatisticsServerState rtssState;
 
+        // Tracks the RTSS process running-state across Update() ticks so we can act
+        // exactly once on a not-running→running transition (init the FPS limiter +
+        // re-apply the current limit). Evaluated regardless of OSD level so FPS
+        // limiting works even with the OSD turned off.
+        private bool rtssWasRunning = false;
+
         // Frametime graph settings - uses <G=<FT>> tag processed by RTSSSharedMemoryNET
         // Width/height are hardcoded in ProcessGraphTags (-32 chars wide, -2 lines tall)
         private float currentMinFt = 0f;
@@ -342,11 +348,15 @@ namespace XboxGamingBarHelper.RTSS
                 var parts = configString.Split(';');
                 foreach (var part in parts)
                 {
-                    var kv = part.Split(':');
-                    if (kv.Length != 2) continue;
+                    if (string.IsNullOrWhiteSpace(part)) continue;
 
-                    var key = kv[0];
-                    var value = kv[1];
+                    // Match ParseOSDConfig: split on the FIRST colon only, so a value
+                    // that itself contains ':' isn't dropped by an exact-2-parts check.
+                    var colonIndex = part.IndexOf(':');
+                    if (colonIndex <= 0) continue;
+
+                    var key = part.Substring(0, colonIndex);
+                    var value = colonIndex < part.Length - 1 ? part.Substring(colonIndex + 1) : "";
 
                     switch (key)
                     {
@@ -496,8 +506,27 @@ namespace XboxGamingBarHelper.RTSS
             {
                 Logger.Debug("Rivatuner Statistics Server is not installed.");
                 rtssState = RivatunerStatisticsServerState.NotInstalled;
+                rtssWasRunning = false;
                 return;
             }
+
+            // Detect the RTSS not-running→running transition once (independent of OSD
+            // level). On that edge, (re)initialize the FPS limiter — this recovers the
+            // case where RTSS was installed/started AFTER the helper (the ctor's one-shot
+            // Initialize would otherwise leave the limiter disabled until a helper
+            // restart) — and re-apply the current FPS limit, which SetFPSLimit silently
+            // drops while RTSS is closed.
+            bool isRTSSRunning = RTSSHelper.IsRunning();
+            if (isRTSSRunning && !rtssWasRunning)
+            {
+                Logger.Info("RTSS became available — (re)initializing FPS limiter and re-applying FPS limit.");
+                RTSSFPSLimiter.Initialize();
+                if (fpsLimit.Value > 0)
+                {
+                    RTSSFPSLimiter.SetFPSLimit(fpsLimit.Value);
+                }
+            }
+            rtssWasRunning = isRTSSRunning;
 
             if (onScreenDisplayLevel == 0)
             {
@@ -518,7 +547,7 @@ namespace XboxGamingBarHelper.RTSS
                 return;
             }
 
-            if (!RTSSHelper.IsRunning())
+            if (!isRTSSRunning)
             {
                 if (SettingsManager.GetInstance().AutoStartRTSS)
                 {

--- a/XboxGamingBarHelper/Services/SystemRestoreService.cs
+++ b/XboxGamingBarHelper/Services/SystemRestoreService.cs
@@ -4,8 +4,10 @@ using System.Diagnostics;
 using System.IO;
 using System.ServiceProcess;
 using System.Text.Json;
+using XboxGamingBarHelper.Devices.Libraries.Legion;
 using XboxGamingBarHelper.Power;
 using XboxGamingBarHelper.Services;
+using XboxGamingBarHelper.Systems;
 
 namespace XboxGamingBarHelper.Services
 {
@@ -53,6 +55,20 @@ namespace XboxGamingBarHelper.Services
             // DAService original state
             public bool? OriginalDAServiceEnabled { get; set; }
             public bool DAServiceSaved { get; set; } = false;
+
+            // Max CPU State original values
+            public uint? OriginalMaxCpuStateAC { get; set; }
+            public uint? OriginalMaxCpuStateDC { get; set; }
+            public bool MaxCpuStateSaved { get; set; } = false;
+
+            // Min CPU State original values
+            public uint? OriginalMinCpuStateAC { get; set; }
+            public uint? OriginalMinCpuStateDC { get; set; }
+            public bool MinCpuStateSaved { get; set; } = false;
+
+            // OS Power Mode (power slider) original value
+            public int? OriginalOsPowerMode { get; set; }
+            public bool OsPowerModeSaved { get; set; } = false;
 
             // Scheduled task was created
             public bool ScheduledTaskCreated { get; set; } = false;
@@ -183,6 +199,71 @@ namespace XboxGamingBarHelper.Services
         }
 
         /// <summary>
+        /// Saves the original Maximum CPU State values before first modification.
+        /// Call this BEFORE changing Max CPU State for the first time.
+        /// </summary>
+        public static void SaveOriginalMaxCpuState(uint currentAC, uint currentDC)
+        {
+            Initialize();
+
+            if (_restoreData.MaxCpuStateSaved)
+            {
+                Logger.Debug("Max CPU State original values already saved, skipping");
+                return;
+            }
+
+            _restoreData.OriginalMaxCpuStateAC = currentAC;
+            _restoreData.OriginalMaxCpuStateDC = currentDC;
+            _restoreData.MaxCpuStateSaved = true;
+            Save();
+
+            Logger.Info($"Saved original Max CPU State values: AC={currentAC}, DC={currentDC}");
+        }
+
+        /// <summary>
+        /// Saves the original Minimum CPU State values before first modification.
+        /// Call this BEFORE changing Min CPU State for the first time.
+        /// </summary>
+        public static void SaveOriginalMinCpuState(uint currentAC, uint currentDC)
+        {
+            Initialize();
+
+            if (_restoreData.MinCpuStateSaved)
+            {
+                Logger.Debug("Min CPU State original values already saved, skipping");
+                return;
+            }
+
+            _restoreData.OriginalMinCpuStateAC = currentAC;
+            _restoreData.OriginalMinCpuStateDC = currentDC;
+            _restoreData.MinCpuStateSaved = true;
+            Save();
+
+            Logger.Info($"Saved original Min CPU State values: AC={currentAC}, DC={currentDC}");
+        }
+
+        /// <summary>
+        /// Saves the original OS Power Mode (power slider) value before first modification.
+        /// Call this BEFORE changing the OS Power Mode for the first time.
+        /// </summary>
+        public static void SaveOriginalOsPowerMode(int currentMode)
+        {
+            Initialize();
+
+            if (_restoreData.OsPowerModeSaved)
+            {
+                Logger.Debug("OS Power Mode original value already saved, skipping");
+                return;
+            }
+
+            _restoreData.OriginalOsPowerMode = currentMode;
+            _restoreData.OsPowerModeSaved = true;
+            Save();
+
+            Logger.Info($"Saved original OS Power Mode value: {currentMode}");
+        }
+
+        /// <summary>
         /// Marks that a scheduled task was created.
         /// </summary>
         public static void MarkScheduledTaskCreated()
@@ -195,8 +276,14 @@ namespace XboxGamingBarHelper.Services
         /// <summary>
         /// Prepares the system for uninstall by reverting all changes.
         /// </summary>
+        /// <param name="legionManager">Optional - releases the EC fan override if a custom fan curve is active.</param>
+        /// <param name="systemManager">Optional - re-enables the touchscreen if GoTweaks disabled it.</param>
+        /// <param name="viiperManager">Optional - stops any live VIIPER emulation session (usbip detach, HidHide, virtual pad teardown).</param>
         /// <returns>A summary of actions taken</returns>
-        public static string PrepareForUninstall()
+        public static string PrepareForUninstall(
+            LegionManager legionManager = null,
+            SystemManager systemManager = null,
+            XboxGamingBarHelper.ControllerEmulation.Viiper.ViiperEmulationManager viiperManager = null)
         {
             Initialize();
 
@@ -319,6 +406,164 @@ namespace XboxGamingBarHelper.Services
             else
             {
                 results.AppendLine("- DAService: No original state saved (was not modified)");
+            }
+
+            // 5. Restore Maximum CPU State %
+            if (_restoreData.MaxCpuStateSaved && _restoreData.OriginalMaxCpuStateAC.HasValue)
+            {
+                try
+                {
+                    Logger.Info($"Uninstall: Restoring Max CPU State to AC={_restoreData.OriginalMaxCpuStateAC}, DC={_restoreData.OriginalMaxCpuStateDC}");
+                    PowerManager.SetMaxCPUState(true, _restoreData.OriginalMaxCpuStateAC.Value);
+                    if (_restoreData.OriginalMaxCpuStateDC.HasValue)
+                    {
+                        PowerManager.SetMaxCPUState(false, _restoreData.OriginalMaxCpuStateDC.Value);
+                    }
+                    results.AppendLine($"✓ Max CPU State restored to: AC={_restoreData.OriginalMaxCpuStateAC}%, DC={_restoreData.OriginalMaxCpuStateDC}%");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Uninstall: Failed to restore Max CPU State: {ex.Message}");
+                    results.AppendLine($"✗ Failed to restore Max CPU State: {ex.Message}");
+                }
+            }
+            else
+            {
+                results.AppendLine("- Max CPU State: No original value saved (was not modified)");
+            }
+
+            // 6. Restore Minimum CPU State %
+            if (_restoreData.MinCpuStateSaved && _restoreData.OriginalMinCpuStateAC.HasValue)
+            {
+                try
+                {
+                    Logger.Info($"Uninstall: Restoring Min CPU State to AC={_restoreData.OriginalMinCpuStateAC}, DC={_restoreData.OriginalMinCpuStateDC}");
+                    PowerManager.SetMinCPUState(true, _restoreData.OriginalMinCpuStateAC.Value);
+                    if (_restoreData.OriginalMinCpuStateDC.HasValue)
+                    {
+                        PowerManager.SetMinCPUState(false, _restoreData.OriginalMinCpuStateDC.Value);
+                    }
+                    results.AppendLine($"✓ Min CPU State restored to: AC={_restoreData.OriginalMinCpuStateAC}%, DC={_restoreData.OriginalMinCpuStateDC}%");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Uninstall: Failed to restore Min CPU State: {ex.Message}");
+                    results.AppendLine($"✗ Failed to restore Min CPU State: {ex.Message}");
+                }
+            }
+            else
+            {
+                results.AppendLine("- Min CPU State: No original value saved (was not modified)");
+            }
+
+            // 7. Restore OS Power Mode (power slider)
+            if (_restoreData.OsPowerModeSaved && _restoreData.OriginalOsPowerMode.HasValue)
+            {
+                try
+                {
+                    Logger.Info($"Uninstall: Restoring OS Power Mode to {_restoreData.OriginalOsPowerMode}");
+                    PowerManager.SetOSPowerMode(_restoreData.OriginalOsPowerMode.Value);
+                    results.AppendLine($"✓ OS Power Mode restored to: {_restoreData.OriginalOsPowerMode}");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Uninstall: Failed to restore OS Power Mode: {ex.Message}");
+                    results.AppendLine($"✗ Failed to restore OS Power Mode: {ex.Message}");
+                }
+            }
+            else
+            {
+                results.AppendLine("- OS Power Mode: No original value saved (was not modified)");
+            }
+
+            // 8. Re-enable the touchscreen if GoTweaks disabled it (SetupAPI device state
+            // persists across reboots and survives an uninstall until manually reverted).
+            if (systemManager != null)
+            {
+                try
+                {
+                    if (systemManager.TouchscreenEnabled != null && systemManager.TouchscreenEnabled.Value == false)
+                    {
+                        Logger.Info("Uninstall: Re-enabling touchscreen...");
+                        systemManager.SetTouchscreenEnabled(true);
+                        results.AppendLine("✓ Touchscreen re-enabled");
+                    }
+                    else
+                    {
+                        results.AppendLine("- Touchscreen: Already enabled (was not modified)");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Uninstall: Failed to re-enable touchscreen: {ex.Message}");
+                    results.AppendLine($"✗ Failed to re-enable touchscreen: {ex.Message}");
+                }
+            }
+
+            // 9. Release the EC fan override (register 0xC6C8) if a custom fan curve is
+            // active, handing fan control back to Lenovo firmware. Otherwise a stuck RPM
+            // survives helper shutdown - the crash-safety hooks only cover process exit,
+            // not this in-app "prepare for uninstall" flow.
+            if (legionManager != null)
+            {
+                try
+                {
+                    Logger.Info("Uninstall: Releasing EC fan override...");
+                    legionManager.StopEcFanCurveLoop();
+                    results.AppendLine("✓ EC fan override released (firmware fan control restored)");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Uninstall: Failed to release EC fan override: {ex.Message}");
+                    results.AppendLine($"✗ Failed to release EC fan override: {ex.Message}");
+                }
+            }
+
+            // 10. Stop any live VIIPER emulation session (usbip detach, HidHide suppression,
+            // virtual pad teardown) before the controller-related cleanup below.
+            if (viiperManager != null)
+            {
+                try
+                {
+                    Logger.Info("Uninstall: Stopping VIIPER emulation...");
+                    viiperManager.Stop();
+                    results.AppendLine("✓ VIIPER emulation stopped");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Uninstall: Failed to stop VIIPER emulation: {ex.Message}");
+                    results.AppendLine($"✗ Failed to stop VIIPER emulation: {ex.Message}");
+                }
+            }
+
+            // 11. Clear our HidHide cloaking rules (blocked device IDs + registered app
+            // paths) so no controller stays hidden from other apps after uninstall.
+            try
+            {
+                Logger.Info("Uninstall: Restoring HidHide state...");
+                UninstallService.RestoreHidHide();
+                results.AppendLine("✓ HidHide cloaking rules cleared");
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Uninstall: Failed to restore HidHide state: {ex.Message}");
+                results.AppendLine($"✗ Failed to restore HidHide state: {ex.Message}");
+            }
+
+            // 12. Sweep any orphaned VIIPER/ViGEm phantom virtual pads left behind by a
+            // prior crash or ungraceful shutdown.
+            try
+            {
+                Logger.Info("Uninstall: Sweeping phantom virtual pads...");
+                ControllerEmulation.Viiper.ViiperPnpCleanup.CleanupPresentViiperPhantomsBlocking();
+                ControllerEmulation.Viiper.ViiperPnpCleanup.CleanupPresentVigemPhantomsBlocking();
+                ControllerEmulation.Viiper.ViiperPnpCleanup.CleanupAllKnownGhosts();
+                results.AppendLine("✓ Phantom virtual pads swept");
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Uninstall: Failed to sweep phantom virtual pads: {ex.Message}");
+                results.AppendLine($"✗ Failed to sweep phantom virtual pads: {ex.Message}");
             }
 
             results.AppendLine();

--- a/XboxGamingBarHelper/Services/UninstallService.cs
+++ b/XboxGamingBarHelper/Services/UninstallService.cs
@@ -94,7 +94,7 @@ namespace XboxGamingBarHelper.Services
         /// controller can never survive us. HidHide itself stays installed
         /// (shared with DS4Windows etc.) unless --remove-drivers.
         /// </summary>
-        private static void RestoreHidHide()
+        internal static void RestoreHidHide()
         {
             HidHideControlService service;
             try

--- a/XboxGamingBarHelper/Settings/SettingsManager.cs
+++ b/XboxGamingBarHelper/Settings/SettingsManager.cs
@@ -132,6 +132,18 @@ namespace XboxGamingBarHelper.Settings
             get { return viiperNintendoSubDevice; }
         }
 
+        private readonly ViiperDesktopButtonTargetProperty viiperDesktopButtonTarget;
+        public ViiperDesktopButtonTargetProperty ViiperDesktopButtonTarget
+        {
+            get { return viiperDesktopButtonTarget; }
+        }
+
+        private readonly ViiperPageButtonTargetProperty viiperPageButtonTarget;
+        public ViiperPageButtonTargetProperty ViiperPageButtonTarget
+        {
+            get { return viiperPageButtonTarget; }
+        }
+
         private readonly ViiperGuideButtonModeProperty viiperGuideButtonMode;
         public ViiperGuideButtonModeProperty ViiperGuideButtonMode
         {
@@ -255,6 +267,8 @@ namespace XboxGamingBarHelper.Settings
             viiperSteamSubDevice = new ViiperSteamSubDeviceProperty(this);
             viiperSonySubDevice = new ViiperSonySubDeviceProperty(this);
             viiperNintendoSubDevice = new ViiperNintendoSubDeviceProperty(this);
+            viiperDesktopButtonTarget = new ViiperDesktopButtonTargetProperty(this);
+            viiperPageButtonTarget = new ViiperPageButtonTargetProperty(this);
             viiperGuideButtonMode = new ViiperGuideButtonModeProperty(this);
             viiperSwapRumbleMotors = new ViiperSwapRumbleMotorsProperty(this);
             viiperRumbleIntensity = new ViiperRumbleIntensityProperty(this);

--- a/XboxGamingBarHelper/Settings/UsbipInstalledProperty.cs
+++ b/XboxGamingBarHelper/Settings/UsbipInstalledProperty.cs
@@ -14,15 +14,19 @@ namespace XboxGamingBarHelper.Settings
     /// </summary>
     internal class UsbipInstalledProperty : HelperProperty<bool, SettingsManager>
     {
-        // Real service names installed by usbip-win2 (verified on a live install).
+        // Service names installed ONLY by usbip-win2. Every entry must be specific to
+        // usbip-win2 — see the false-positive note below.
         private static readonly string[] ServiceKeyNames = new[]
         {
-            "usbip2_ude",      // primary — USB Device Emulation (driver)
+            "usbip2_ude",      // primary — USB Device Emulation driver (usbip-win2 UDE releases)
             "usbip2_filter",   // upper filter driver
-            "mausbip",         // MsUsbIp service
-            // Historical / alternate names, kept for safety:
-            "usbip2vhci",
-            "VHCI",
+            "usbip2vhci",      // older usbip-win2 vhci-based releases
+            // DO NOT add generic names like "mausbip" or bare "VHCI". They are NOT
+            // usbip-win2 — they exist on stock machines from unrelated components, and
+            // matching them false-positived Detect()=>true on a system with NO usbip-win2.
+            // That let the VIIPER backend run with no real driver: HidHide hid the physical
+            // pad, the virtual pad never mounted (no vhci to surface it), and the controller
+            // went dead. usbip.exe (below) + the usbip2_* drivers are the only valid signals.
         };
 
         private static readonly string[] BinaryPaths = new[]

--- a/XboxGamingBarHelper/Settings/ViiperFrontButtonTargetProperties.cs
+++ b/XboxGamingBarHelper/Settings/ViiperFrontButtonTargetProperties.cs
@@ -1,0 +1,68 @@
+using Shared.Enums;
+using XboxGamingBarHelper.Core;
+
+namespace XboxGamingBarHelper.Settings
+{
+    /// <summary>
+    /// Which emulated-controller button the Legion "Desktop" front button acts as while
+    /// controller emulation is active. String value: none|guide|touchpad|share|options|l3|r3.
+    /// Resolved per emulated type in the VIIPER forwarder. Default "guide" matches the prior
+    /// hardcoded behavior (Desktop -> PS/Guide).
+    /// </summary>
+    internal class ViiperDesktopButtonTargetProperty : HelperProperty<string, SettingsManager>
+    {
+        public const string Default = "guide";
+        private const string SettingsKey = "ViiperDesktopButtonTarget";
+
+        public ViiperDesktopButtonTargetProperty(SettingsManager inManager)
+            : base(LoadFromSettings(), null, Function.Viiper_DesktopButtonTarget, inManager)
+        {
+            Logger.Info($"ViiperDesktopButtonTarget loaded: {Value}");
+        }
+
+        private static string LoadFromSettings()
+        {
+            if (LocalSettingsHelper.TryGetValue<string>(SettingsKey, out var value) && !string.IsNullOrEmpty(value))
+                return value;
+            return Default;
+        }
+
+        protected override void NotifyPropertyChanged(string propertyName = "")
+        {
+            base.NotifyPropertyChanged(propertyName);
+            Logger.Info($"ViiperDesktopButtonTarget changed: {Value}");
+            LocalSettingsHelper.SetValue(SettingsKey, Value ?? Default);
+        }
+    }
+
+    /// <summary>
+    /// Which emulated-controller button the Legion "Page" front button acts as while controller
+    /// emulation is active. String value: none|guide|touchpad|share|options|l3|r3. Default
+    /// "touchpad" matches the prior hardcoded behavior (Page -> Touchpad click).
+    /// </summary>
+    internal class ViiperPageButtonTargetProperty : HelperProperty<string, SettingsManager>
+    {
+        public const string Default = "touchpad";
+        private const string SettingsKey = "ViiperPageButtonTarget";
+
+        public ViiperPageButtonTargetProperty(SettingsManager inManager)
+            : base(LoadFromSettings(), null, Function.Viiper_PageButtonTarget, inManager)
+        {
+            Logger.Info($"ViiperPageButtonTarget loaded: {Value}");
+        }
+
+        private static string LoadFromSettings()
+        {
+            if (LocalSettingsHelper.TryGetValue<string>(SettingsKey, out var value) && !string.IsNullOrEmpty(value))
+                return value;
+            return Default;
+        }
+
+        protected override void NotifyPropertyChanged(string propertyName = "")
+        {
+            base.NotifyPropertyChanged(propertyName);
+            Logger.Info($"ViiperPageButtonTarget changed: {Value}");
+            LocalSettingsHelper.SetValue(SettingsKey, Value ?? Default);
+        }
+    }
+}

--- a/XboxGamingBarHelper/Startup/Program.Labs.cs
+++ b/XboxGamingBarHelper/Startup/Program.Labs.cs
@@ -40,8 +40,15 @@ namespace XboxGamingBarHelper
     internal partial class Program
     {
         /// <summary>
-        /// Get the current status of DAService (Legion Space service).
-        /// Returns: 0 = Stopped, 1 = Running, 2 = Not Found, 3 = Stopping, 4 = Starting
+        /// Get the current status of DAService (Legion Space service). Reports the startup
+        /// state, NOT the transient run state (StartType is set instantly by sc.exe, so this
+        /// is accurate immediately).
+        ///   1 = Enabled  → auto-starts at boot (StartType == Automatic).
+        ///   0 = Disabled → won't auto-start at boot. We use Manual ("demand"), NOT Windows-
+        ///                  Disabled, so the user can still launch Legion Space on demand; the
+        ///                  service just doesn't return after a reboot. (Windows-Disabled would
+        ///                  also read as 0 here, for back-compat with older installs.)
+        ///   2 = Not Found.
         /// </summary>
         private static int GetDAServiceStatus()
         {
@@ -49,19 +56,9 @@ namespace XboxGamingBarHelper
             {
                 using (var sc = new ServiceController("DAService"))
                 {
-                    var status = sc.Status;
-                    Logger.Debug($"Labs: DAService status = {status}");
-                    switch (status)
-                    {
-                        case ServiceControllerStatus.Running:
-                            return 1;
-                        case ServiceControllerStatus.StopPending:
-                            return 3; // Stopping
-                        case ServiceControllerStatus.StartPending:
-                            return 4; // Starting
-                        default:
-                            return 0; // Stopped or other
-                    }
+                    var startType = sc.StartType;
+                    Logger.Debug($"Labs: DAService StartType = {startType}, Status = {sc.Status}");
+                    return startType == ServiceStartMode.Automatic ? 1 : 0;
                 }
             }
             catch (InvalidOperationException)
@@ -77,21 +74,30 @@ namespace XboxGamingBarHelper
         }
 
         /// <summary>
-        /// Control DAService (Legion Space service).
-        /// Action: 0 = Stop and Disable, 1 = Enable and Start
+        /// Control DAService (Legion Space service) startup type.
+        /// Action: 0 = Disable auto-start — set startup to Manual ("demand") + stop the running
+        ///         instance. The daemon no longer runs at boot and does NOT return after a reboot,
+        ///         but Legion Space can STILL start it on demand (unlike Windows-Disabled, which
+        ///         blocks launching it entirely). 1 = Enable — set startup to auto + start now.
+        ///
+        /// The startup-type change (sc.exe config) is applied synchronously and is fast — that's
+        /// the part GetDAServiceStatus reports. The actual stop/start of the running instance is
+        /// kicked off on a background task so we never block the pipe handler thread on
+        /// WaitForStatus (which could exceed the widget's 10 s request timeout and wedge the pipe).
         /// </summary>
         private static void ControlDAService(int action)
         {
             try
             {
-                if (action == 0) // Stop and Disable
+                if (action == 0) // Disable auto-start (Manual/demand)
                 {
-                    // Save original state before first modification (for clean uninstall)
+                    // Save the original ENABLED (auto-start) state before the first modification
+                    // so a clean uninstall can restore it correctly.
                     try
                     {
                         using (var sc = new ServiceController("DAService"))
                         {
-                            bool wasEnabled = sc.Status == ServiceControllerStatus.Running;
+                            bool wasEnabled = sc.StartType == ServiceStartMode.Automatic;
                             Services.SystemRestoreService.SaveOriginalDAServiceState(wasEnabled);
                         }
                     }
@@ -100,70 +106,95 @@ namespace XboxGamingBarHelper
                         Logger.Warn($"Failed to save original DAService state: {ex.Message}");
                     }
 
-                    // First stop the service
-                    using (var sc = new ServiceController("DAService"))
-                    {
-                        if (sc.Status == ServiceControllerStatus.Running)
-                        {
-                            Logger.Info("Labs: Stopping DAService...");
-                            sc.Stop();
-                            sc.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.FromSeconds(10));
-                            Logger.Info("Labs: DAService stopped");
-                        }
-                    }
+                    // Set startup to Manual ("demand"): won't auto-start at boot (so it doesn't
+                    // return after a reboot), but stays launchable on demand by Legion Space.
+                    SetDAServiceStartType("demand");
 
-                    // Then disable the service startup type using sc.exe
-                    Logger.Info("Labs: Disabling DAService startup...");
-                    var disableProcess = new Process
+                    // Then stop the running instance in the background (best-effort).
+                    Task.Run(() =>
                     {
-                        StartInfo = new ProcessStartInfo
+                        try
                         {
-                            FileName = "sc.exe",
-                            Arguments = "config DAService start= disabled",
-                            UseShellExecute = false,
-                            CreateNoWindow = true,
-                            RedirectStandardOutput = true
+                            using (var sc = new ServiceController("DAService"))
+                            {
+                                if (sc.Status == ServiceControllerStatus.Running)
+                                {
+                                    Logger.Info("Labs: Stopping DAService (background)...");
+                                    sc.Stop();
+                                    sc.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.FromSeconds(15));
+                                    Logger.Info("Labs: DAService stopped");
+                                }
+                            }
                         }
-                    };
-                    disableProcess.Start();
-                    disableProcess.WaitForExit(5000);
-                    Logger.Info($"Labs: DAService startup disabled (exit code: {disableProcess.ExitCode})");
+                        catch (Exception ex)
+                        {
+                            Logger.Warn($"Labs: background DAService stop failed: {ex.Message}");
+                        }
+                    });
                 }
-                else // Enable and Start
+                else // Enable auto-start
                 {
-                    // First enable the service startup type using sc.exe
-                    Logger.Info("Labs: Enabling DAService startup...");
-                    var enableProcess = new Process
-                    {
-                        StartInfo = new ProcessStartInfo
-                        {
-                            FileName = "sc.exe",
-                            Arguments = "config DAService start= auto",
-                            UseShellExecute = false,
-                            CreateNoWindow = true,
-                            RedirectStandardOutput = true
-                        }
-                    };
-                    enableProcess.Start();
-                    enableProcess.WaitForExit(5000);
-                    Logger.Info($"Labs: DAService startup enabled (exit code: {enableProcess.ExitCode})");
+                    // Restore the startup type to auto.
+                    SetDAServiceStartType("auto");
 
-                    // Then start the service
-                    using (var sc = new ServiceController("DAService"))
+                    // Then start the service in the background (best-effort).
+                    Task.Run(() =>
                     {
-                        if (sc.Status == ServiceControllerStatus.Stopped)
+                        try
                         {
-                            Logger.Info("Labs: Starting DAService...");
-                            sc.Start();
-                            sc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(10));
-                            Logger.Info("Labs: DAService started");
+                            using (var sc = new ServiceController("DAService"))
+                            {
+                                if (sc.Status == ServiceControllerStatus.Stopped)
+                                {
+                                    Logger.Info("Labs: Starting DAService (background)...");
+                                    sc.Start();
+                                    sc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(15));
+                                    Logger.Info("Labs: DAService started");
+                                }
+                            }
                         }
-                    }
+                        catch (Exception ex)
+                        {
+                            Logger.Warn($"Labs: background DAService start failed: {ex.Message}");
+                        }
+                    });
                 }
             }
             catch (Exception ex)
             {
                 Logger.Error($"Labs: Error controlling DAService: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Sets DAService's startup type via sc.exe ("demand" = Manual, or "auto"). Synchronous
+        /// and fast; this is the startup state GetDAServiceStatus reports.
+        /// </summary>
+        private static void SetDAServiceStartType(string startMode)
+        {
+            try
+            {
+                Logger.Info($"Labs: Setting DAService startup to {startMode}...");
+                using (var proc = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = "sc.exe",
+                        Arguments = $"config DAService start= {startMode}",
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                        RedirectStandardOutput = true
+                    }
+                })
+                {
+                    proc.Start();
+                    proc.WaitForExit(5000);
+                    Logger.Info($"Labs: DAService startup set to {startMode} (exit code: {proc.ExitCode})");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Labs: Failed to set DAService startup to {startMode}: {ex.Message}");
             }
         }
 

--- a/XboxGamingBarHelper/Startup/Program.PipeHandlers.cs
+++ b/XboxGamingBarHelper/Startup/Program.PipeHandlers.cs
@@ -897,7 +897,9 @@ namespace XboxGamingBarHelper
                     {
                         int action = Convert.ToInt32(request.Content);
                         ControlDAService(action);
-                        System.Threading.Thread.Sleep(500);
+                        // No sleep needed: ControlDAService applies the permanent startup-type change
+                        // synchronously (the background task only handles the slow stop/start), and
+                        // GetDAServiceStatus reports that StartType — so it's already accurate here.
                         int status = GetDAServiceStatus();
                         response = new global::Windows.Foundation.Collections.ValueSet();
                         response.Add(nameof(Function), (int)Function.Labs_DAServiceStatus);
@@ -1437,7 +1439,7 @@ namespace XboxGamingBarHelper
 
                     try
                     {
-                        string result = Services.SystemRestoreService.PrepareForUninstall();
+                        string result = Services.SystemRestoreService.PrepareForUninstall(legionManager, systemManager, viiperEmulationManager);
                         response.Add(nameof(Function), functionValue);
                         response.Add("Content", result);
                         response.Add("UpdatedTime", DateTimeOffset.Now.ToUnixTimeMilliseconds());

--- a/XboxGamingBarHelper/Systems/SystemManager.cs
+++ b/XboxGamingBarHelper/Systems/SystemManager.cs
@@ -187,6 +187,13 @@ namespace XboxGamingBarHelper.Systems
             get { return panelBrightnessSupported; }
         }
 
+        private const string TouchscreenEnabledKey = "TouchscreenEnabled";
+        private readonly TouchscreenEnabledProperty touchscreenEnabled;
+        public TouchscreenEnabledProperty TouchscreenEnabled
+        {
+            get { return touchscreenEnabled; }
+        }
+
         private readonly AdaptiveBrightnessModeProperty adaptiveBrightnessMode;
         public AdaptiveBrightnessModeProperty AdaptiveBrightnessMode
         {
@@ -286,6 +293,19 @@ namespace XboxGamingBarHelper.Systems
             adaptiveBrightnessMode = new AdaptiveBrightnessModeProperty(this);
             panelBrightness = new PanelBrightnessProperty(this);
             panelBrightnessSupported = new PanelBrightnessSupportedProperty(this);
+
+            // Touch screen: persist the user's last choice across helper restarts. Default true
+            // (touch active) if never set. No need to re-apply on startup - Device Manager's
+            // disabled state is itself persistent at the OS level (survives reboots/helper
+            // restarts on its own), we're just mirroring it in the UI. Default true also means
+            // a fresh install never starts with touch off.
+            bool touchscreenInitial = true;
+            if (XboxGamingBarHelper.Settings.LocalSettingsHelper.TryGetValue<bool>(TouchscreenEnabledKey, out var savedTouchscreenEnabled))
+            {
+                touchscreenInitial = savedTouchscreenEnabled;
+            }
+            touchscreenEnabled = new TouchscreenEnabledProperty(touchscreenInitial, this);
+
             // Master AB toggle lives inside the OSD/Display bundle and is only re-sent on
             // widget change — so a helper restart loses the in-memory "requested" flag.
             // Persist it locally and re-apply on startup so mode flips work after restarts.
@@ -1630,6 +1650,26 @@ namespace XboxGamingBarHelper.Systems
         {
             // Re-apply the current requested state so the right backend ends up running.
             ApplyAdaptiveBrightnessBackend(adaptiveBrightnessRequested, mode);
+        }
+
+        // Disables/enables the built-in touch screen digitizer via SetupAPI (Device Manager's
+        // own "Disable device" mechanism). Matches by HID compatible ID (UP:000D_U:0004 =
+        // Digitizer usage page + Touch Screen usage), not the friendly name/VID/PID - the
+        // friendly name is localized by Windows ("HID-compliant touch screen" becomes e.g.
+        // "Ekran dotykowy zgodny z HID" on Polish Windows) so name matching silently found
+        // nothing on non-English installs; the compatible ID is generic and never localized.
+        public void SetTouchscreenEnabled(bool enabled)
+        {
+            try { XboxGamingBarHelper.Settings.LocalSettingsHelper.SetValue(TouchscreenEnabledKey, enabled); } catch { }
+            try
+            {
+                int touched = SetupApi.SetHidDeviceEnabled("UP:000D_U:0004", enabled);
+                Logger.Info($"SetTouchscreenEnabled({enabled}): {touched} matching HID device(s) toggled");
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"SetTouchscreenEnabled({enabled}) failed: {ex.Message}");
+            }
         }
 
         private void ApplyAdaptiveBrightnessBackend(bool requested, Shared.Enums.AdaptiveBrightnessMode mode)

--- a/XboxGamingBarHelper/Systems/TouchscreenEnabledProperty.cs
+++ b/XboxGamingBarHelper/Systems/TouchscreenEnabledProperty.cs
@@ -1,0 +1,23 @@
+using Shared.Enums;
+using XboxGamingBarHelper.Core;
+
+namespace XboxGamingBarHelper.Systems
+{
+    // Enable/disable the built-in touch screen digitizer (SetupAPI device disable - see
+    // XboxGamingBarHelper.Windows.SetupApi). Persisted across restarts - this is a deliberate
+    // user preference (e.g. "always play with the controller, avoid accidental touches"),
+    // not transient UI state.
+    internal class TouchscreenEnabledProperty : HelperProperty<bool, SystemManager>
+    {
+        public TouchscreenEnabledProperty(bool initialValue, SystemManager inManager)
+            : base(initialValue, null, Function.TouchscreenEnabled, inManager)
+        {
+        }
+
+        protected override void NotifyPropertyChanged(string propertyName = "")
+        {
+            base.NotifyPropertyChanged(propertyName);
+            Manager?.SetTouchscreenEnabled(Value);
+        }
+    }
+}

--- a/XboxGamingBarHelper/Windows/SetupApi.cs
+++ b/XboxGamingBarHelper/Windows/SetupApi.cs
@@ -1,0 +1,210 @@
+using NLog;
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace XboxGamingBarHelper.Windows
+{
+    // Enable/disable a Device Manager node (SetupAPI DIF_PROPERTYCHANGE), the same mechanism
+    // Device Manager's own "Disable device" context-menu entry uses. Requires elevation
+    // (our helper always runs elevated).
+    internal static class SetupApi
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        private static readonly Guid GUID_DEVCLASS_HIDCLASS = new Guid("745a17a0-74d3-11d0-b6fe-00a0c90f57da");
+
+        private const uint DIGCF_PRESENT = 0x02;
+        private const uint SPDRP_DEVICEDESC = 0x00;
+        private const uint SPDRP_HARDWAREID = 0x01;
+        private const uint SPDRP_COMPATIBLEIDS = 0x02;
+        private const uint SPDRP_FRIENDLYNAME = 0x0C;
+        private const uint DIF_PROPERTYCHANGE = 0x12;
+        private const uint DICS_ENABLE = 1;
+        private const uint DICS_DISABLE = 2;
+        private const uint DICS_FLAG_GLOBAL = 1;
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SP_DEVINFO_DATA
+        {
+            public uint cbSize;
+            public Guid ClassGuid;
+            public uint DevInst;
+            public IntPtr Reserved;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SP_CLASSINSTALL_HEADER
+        {
+            public uint cbSize;
+            public uint InstallFunction;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SP_PROPCHANGE_PARAMS
+        {
+            public SP_CLASSINSTALL_HEADER ClassInstallHeader;
+            public uint StateChange;
+            public uint Scope;
+            public uint HwProfile;
+        }
+
+        [DllImport("setupapi.dll", SetLastError = true)]
+        private static extern IntPtr SetupDiGetClassDevs(ref Guid ClassGuid, IntPtr Enumerator, IntPtr hwndParent, uint Flags);
+
+        [DllImport("setupapi.dll", SetLastError = true)]
+        private static extern bool SetupDiEnumDeviceInfo(IntPtr DeviceInfoSet, uint MemberIndex, ref SP_DEVINFO_DATA DeviceInfoData);
+
+        [DllImport("setupapi.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern bool SetupDiGetDeviceRegistryProperty(IntPtr DeviceInfoSet, ref SP_DEVINFO_DATA DeviceInfoData,
+            uint Property, out uint PropertyRegDataType, byte[] PropertyBuffer, uint PropertyBufferSize, out uint RequiredSize);
+
+        [DllImport("setupapi.dll", SetLastError = true)]
+        private static extern bool SetupDiSetClassInstallParams(IntPtr DeviceInfoSet, ref SP_DEVINFO_DATA DeviceInfoData,
+            ref SP_PROPCHANGE_PARAMS ClassInstallParams, uint ClassInstallParamsSize);
+
+        [DllImport("setupapi.dll", SetLastError = true)]
+        private static extern bool SetupDiCallClassInstaller(uint InstallFunction, IntPtr DeviceInfoSet, ref SP_DEVINFO_DATA DeviceInfoData);
+
+        [DllImport("setupapi.dll", SetLastError = true)]
+        private static extern bool SetupDiDestroyDeviceInfoList(IntPtr DeviceInfoSet);
+
+        /// <summary>
+        /// Enables or disables every present HID-class device whose Hardware IDs / Compatible
+        /// IDs contain <paramref name="idContains"/> (case-insensitive) - e.g.
+        /// "HID_DEVICE_UP:000D_U:0004", Windows' own generic compatible ID for any HID device
+        /// declaring Usage Page 0x0D (Digitizer) + Usage 0x04 (Touch Screen) in its report
+        /// descriptor. Matching on this instead of the friendly name/device description is
+        /// deliberate: those strings are LOCALIZED by Windows ("HID-compliant touch screen"
+        /// becomes e.g. "Ekran dotykowy zgodny z HID" on Polish Windows), so name-based
+        /// matching silently fails on any non-English install. Hardware/Compatible IDs are
+        /// never localized. Returns the number of matching devices successfully toggled.
+        /// </summary>
+        public static int SetHidDeviceEnabled(string idContains, bool enabled)
+        {
+            int touched = 0;
+            Guid hidClassGuid = GUID_DEVCLASS_HIDCLASS;
+            IntPtr deviceInfoSet = SetupDiGetClassDevs(ref hidClassGuid, IntPtr.Zero, IntPtr.Zero, DIGCF_PRESENT);
+            if (deviceInfoSet == IntPtr.Zero || deviceInfoSet.ToInt64() == -1)
+            {
+                Logger.Warn($"SetHidDeviceEnabled: SetupDiGetClassDevs failed (error {Marshal.GetLastWin32Error()})");
+                return 0;
+            }
+
+            try
+            {
+                uint index = 0;
+                while (true)
+                {
+                    var devInfoData = new SP_DEVINFO_DATA();
+                    devInfoData.cbSize = (uint)Marshal.SizeOf(typeof(SP_DEVINFO_DATA));
+                    if (!SetupDiEnumDeviceInfo(deviceInfoSet, index, ref devInfoData))
+                    {
+                        break; // ERROR_NO_MORE_ITEMS
+                    }
+                    index++;
+
+                    if (!HasMatchingId(deviceInfoSet, ref devInfoData, idContains))
+                    {
+                        continue;
+                    }
+                    string name = GetDeviceName(deviceInfoSet, ref devInfoData) ?? "(unnamed)";
+
+                    var propChangeParams = new SP_PROPCHANGE_PARAMS
+                    {
+                        ClassInstallHeader = new SP_CLASSINSTALL_HEADER
+                        {
+                            cbSize = (uint)Marshal.SizeOf(typeof(SP_CLASSINSTALL_HEADER)),
+                            InstallFunction = DIF_PROPERTYCHANGE
+                        },
+                        StateChange = enabled ? DICS_ENABLE : DICS_DISABLE,
+                        Scope = DICS_FLAG_GLOBAL,
+                        HwProfile = 0
+                    };
+
+                    if (!SetupDiSetClassInstallParams(deviceInfoSet, ref devInfoData, ref propChangeParams, (uint)Marshal.SizeOf(typeof(SP_PROPCHANGE_PARAMS))))
+                    {
+                        Logger.Warn($"SetHidDeviceEnabled: SetupDiSetClassInstallParams failed for '{name}' (error {Marshal.GetLastWin32Error()})");
+                        continue;
+                    }
+
+                    if (!SetupDiCallClassInstaller(DIF_PROPERTYCHANGE, deviceInfoSet, ref devInfoData))
+                    {
+                        Logger.Warn($"SetHidDeviceEnabled: SetupDiCallClassInstaller failed for '{name}' (error {Marshal.GetLastWin32Error()})");
+                        continue;
+                    }
+
+                    Logger.Info($"SetHidDeviceEnabled: '{name}' -> {(enabled ? "enabled" : "disabled")}");
+                    touched++;
+                }
+            }
+            finally
+            {
+                SetupDiDestroyDeviceInfoList(deviceInfoSet);
+            }
+
+            return touched;
+        }
+
+        private static bool HasMatchingId(IntPtr deviceInfoSet, ref SP_DEVINFO_DATA devInfoData, string idContains)
+        {
+            foreach (var id in GetDeviceRegistryPropertyMultiSz(deviceInfoSet, ref devInfoData, SPDRP_COMPATIBLEIDS))
+            {
+                if (id.IndexOf(idContains, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+            }
+            foreach (var id in GetDeviceRegistryPropertyMultiSz(deviceInfoSet, ref devInfoData, SPDRP_HARDWAREID))
+            {
+                if (id.IndexOf(idContains, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+            }
+            return false;
+        }
+
+        private static string GetDeviceName(IntPtr deviceInfoSet, ref SP_DEVINFO_DATA devInfoData)
+        {
+            string friendly = GetDeviceRegistryProperty(deviceInfoSet, ref devInfoData, SPDRP_FRIENDLYNAME);
+            if (!string.IsNullOrEmpty(friendly))
+            {
+                return friendly;
+            }
+            return GetDeviceRegistryProperty(deviceInfoSet, ref devInfoData, SPDRP_DEVICEDESC);
+        }
+
+        private static string GetDeviceRegistryProperty(IntPtr deviceInfoSet, ref SP_DEVINFO_DATA devInfoData, uint property)
+        {
+            SetupDiGetDeviceRegistryProperty(deviceInfoSet, ref devInfoData, property, out _, null, 0, out uint requiredSize);
+            if (requiredSize == 0)
+            {
+                return null;
+            }
+
+            var buffer = new byte[requiredSize];
+            if (!SetupDiGetDeviceRegistryProperty(deviceInfoSet, ref devInfoData, property, out _, buffer, requiredSize, out _))
+            {
+                return null;
+            }
+
+            return Encoding.Unicode.GetString(buffer).TrimEnd('\0');
+        }
+
+        // SPDRP_HARDWAREID / SPDRP_COMPATIBLEIDS are REG_MULTI_SZ: a sequence of null-terminated
+        // strings, terminated by an extra empty string (double null overall). These IDs are
+        // driver/PnP-generated and never localized (unlike SPDRP_FRIENDLYNAME/SPDRP_DEVICEDESC).
+        private static string[] GetDeviceRegistryPropertyMultiSz(IntPtr deviceInfoSet, ref SP_DEVINFO_DATA devInfoData, uint property)
+        {
+            SetupDiGetDeviceRegistryProperty(deviceInfoSet, ref devInfoData, property, out _, null, 0, out uint requiredSize);
+            if (requiredSize == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            var buffer = new byte[requiredSize];
+            if (!SetupDiGetDeviceRegistryProperty(deviceInfoSet, ref devInfoData, property, out _, buffer, requiredSize, out _))
+            {
+                return Array.Empty<string>();
+            }
+
+            string raw = Encoding.Unicode.GetString(buffer);
+            return raw.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+    }
+}

--- a/XboxGamingBarHelper/XboxGamingBarHelper.csproj
+++ b/XboxGamingBarHelper/XboxGamingBarHelper.csproj
@@ -586,6 +586,7 @@
     <Compile Include="Settings\ViiperAlternateGyroConventionProperty.cs" />
     <Compile Include="Settings\ViiperSteamSubDeviceProperty.cs" />
     <Compile Include="Settings\ViiperSonySubDeviceProperty.cs" />
+    <Compile Include="Settings\ViiperFrontButtonTargetProperties.cs" />
     <Compile Include="Settings\ViiperNintendoSubDeviceProperty.cs" />
     <Compile Include="Settings\ViiperGuideButtonModeProperty.cs" />
     <Compile Include="Settings\ViiperSwapRumbleMotorsProperty.cs" />

--- a/XboxGamingBarHelper/XboxGamingBarHelper.csproj
+++ b/XboxGamingBarHelper/XboxGamingBarHelper.csproj
@@ -567,6 +567,7 @@
     <Compile Include="Settings\EmulationBackendProperty.cs" />
     <Compile Include="ControllerEmulation\Viiper\LibViiper.cs" />
     <Compile Include="ControllerEmulation\Viiper\ViiperService.cs" />
+    <Compile Include="ControllerEmulation\Viiper\UsbipCli.cs" />
     <Compile Include="ControllerEmulation\Viiper\ViiperModels.cs" />
     <Compile Include="ControllerEmulation\Viiper\VirtualButtonNames.cs" />
     <Compile Include="ControllerEmulation\Viiper\InputStateSnapshot.cs" />
@@ -624,6 +625,7 @@
     <Compile Include="Systems\AdaptiveBrightnessModeProperty.cs" />
     <Compile Include="Systems\PanelBrightnessProperty.cs" />
     <Compile Include="Systems\PanelBrightnessSupportedProperty.cs" />
+    <Compile Include="Systems\TouchscreenEnabledProperty.cs" />
     <Compile Include="Systems\AdaptiveBrightnessManager.cs" />
     <Compile Include="Systems\BrightnessManager.cs" />
     <Compile Include="Systems\CPUCoreConfigProperty.cs" />
@@ -639,6 +641,7 @@
     <Compile Include="Windows\PowerGuids.cs" />
     <Compile Include="Windows\PowrProf.cs" />
     <Compile Include="Windows\ProcessWindow.cs" />
+    <Compile Include="Windows\SetupApi.cs" />
     <Compile Include="Windows\User32.cs" />
     <Compile Include="Systems\SystemManager.cs" />
     <Compile Include="Devices\DeviceConfig.cs" />

--- a/XboxGamingBarPackage/Package.appxmanifest
+++ b/XboxGamingBarPackage/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap uap3 mp rescap">
-  <Identity Name="PlayandBuildCustom.10365195AA1EC" Publisher="CN=dg" Version="0.3.2613.0" />
+  <Identity Name="PlayandBuildCustom.10365195AA1EC" Publisher="CN=dg" Version="0.3.2615.0" />
   <mp:PhoneIdentity PhoneProductId="c2dd2cd0-7156-428e-b305-d3dd3505b10d" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>GoTweaks</DisplayName>

--- a/XboxGamingBarPackage/Package.appxmanifest
+++ b/XboxGamingBarPackage/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap uap3 mp rescap">
-  <Identity Name="PlayandBuildCustom.10365195AA1EC" Publisher="CN=dg" Version="0.3.2615.0" />
+  <Identity Name="PlayandBuildCustom.10365195AA1EC" Publisher="CN=dg" Version="0.3.2616.0" />
   <mp:PhoneIdentity PhoneProductId="c2dd2cd0-7156-428e-b305-d3dd3505b10d" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>GoTweaks</DisplayName>


### PR DESCRIPTION
Ports 15 vetted items from the Rayekkk/GoTweaks-Lite fork onto release/v0.3.98.0. Each was diff-checked against our tree first — everything already present locally was skipped.

## Reliability fixes
- **usbip detection false positives** — `UsbipInstalledProperty` no longer matches `mausbip`/generic VHCI service names that exist on stock machines (VIIPER engaging with no driver → dead controller).
- **UsbipCli explicit attach/detach** — drives `usbip.exe attach` idempotently after device add and detaches all on stop; fixes libviiper auto-attach silently no-oping on some usbip-win2 UDE installs. Needs on-device validation.
- **Widget pipe lifecycle** — Game Bar can recreate the widget page in place; we now rebind the static pipe events in `OnNavigatedTo` and detach in `Unloaded` (fixes frozen Quick Metrics + dead-instance handler leak).
- **HID read starvation** — `LegionButtonMonitor` force-reconnects after ~2s of `WAIT_TIMEOUT` reads (was ~100s dead after HidHide port cycle).
- **VIIPER crash cleanup** — `ProcessExit`/`UnhandledException` hooks now dispose the VIIPER manager (no more phantom pads after a helper crash).
- **RTSS limiter recovery** — limiter initializes and the FPS limit re-applies when RTSS starts after the helper; `ParseDisplayOSDConfig` splits on first colon.
- **Legion PawnIO TDP verification** — dedicated WMI read-back after PawnIO writes (old path was dead code behind the ManufacturerWMI gate).
- **ADLX wattage fallback** — targets the correct physical sensor after the LeGo2 CPU/GPU wattage swap.

## Behavior fixes
- **Profile delete completeness** — also removes the controller-profile container, disabled-key, and helper-side per-game XML (profiles no longer resurrect); repeat deletes work via silent trigger reset.
- **DAService** — disable now sets `start= demand` (Legion Space stays launchable), status reflects StartType, stop/start moved off the pipe thread; widget strings updated.
- **LosslessScaling** — detected without requiring `Settings.xml` (fresh installs showed "Not Installed"), 10s runtime re-detection, 3-char minimum title filter, thread-safety, quieter logging.
- **Uninstall prep** — first-touch snapshots + restore of Max/Min CPU state and OS power mode, EC fan override release, VIIPER stop, HidHide clear, phantom-pad sweep, touchscreen re-enable; dialog text updated.
- **Controller status** — status line computed from real attach/battery/VID:PID state instead of a hardcoded "Connected"; info section shows when either VID:PID or device status arrives.

## Features
- **Touchscreen quick toggle** — QS tile (Legion Go only) enabling/disabling the HID digitizer via SetupApi (`UP:000D_U:0004` match), persisted; re-enabled on uninstall prep. Includes the bundled close-to-minimize `Visible` gate fix in `App.xaml.cs`.
- **Win11 theme** — new entry in the existing theme selector: flat neutral tiles with a live-accent bottom bar instead of background tints, Segoe Fluent icons, severity colors on the bar (our richer battery/TDP semantics kept), icon/value/label metrics layout, CornerRadius-10 hairline cards with SemiBold titles. All other themes render pixel-identical to before; switching rebuilds the tiles live.

## Notes
- `Function` enum entries appended at the end (positional wire IDs preserved).
- Verified: full Debug package build succeeds (0.3.2615.0 msixbundle + helper exe). Not yet exercised on hardware — UsbipCli attach flow, touchscreen toggle, and Win11 theme visuals deserve an on-device pass.
- Deliberately not ported: fork's Lite rebrand/inline color long-tail, Task View Labs fix, brightness gesture, port-cycle escalation (needs Go S gating), 12h clock (ours is a flag), OEM widget bookkeeping (fork reverted it).